### PR TITLE
Update scraper subgraph to 2026-04-05-4492

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -12,7 +12,7 @@ import assert from "assert";
 
 /** Goldsky-hosted Cyclo subgraph endpoint for the current epoch */
 const SUBGRAPH_URL =
-  "https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-02-13-78a0/gn";
+  "https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-05-4492/gn";
 const BATCH_SIZE = 1000;
 
 const epoch = EPOCHS[CURRENT_EPOCH - 1];


### PR DESCRIPTION
## Summary
- Update scraper subgraph URL from `2026-02-13-78a0` to `2026-04-05-4492`
- Same subgraph the site now uses — consolidates to a single Flare deployment
- `78a0` can be deleted from Goldsky after both this and cyclofinance/cyclo.site#289 merge

## Test plan
- [x] All 463 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)