### PR TITLE
Fix easy audit items

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { generateSnapshotBlocks, scaleTo18, parseEnv, isSameAddress, REWARDS_SOURCES, FACTORIES, CYTOKENS } from './config';
 import { VALID_ADDRESS_REGEX, EPOCHS, CURRENT_EPOCH } from './constants';
 
-describe('Test generateSnapshotTimestampForEpoch', () => {
+describe('generateSnapshotBlocks', () => {
   
   const start = 5000;
   const end = 9000;

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -99,7 +99,7 @@ describe("Processor", () => {
   });
 
   describe("Basic Transfer Processing", () => {
-    it("should track approved transfers correctly", async () => {
+    it("should give zero eligible balance for approved buy without LP deposit", async () => {
       const transfer: Transfer = {
         from: APPROVED_SOURCE,
         to: NORMAL_USER_1,

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -6,8 +6,7 @@
 import { request, gql } from "graphql-request";
 import { writeFile } from "fs/promises";
 import { LiquidityChange, LiquidityChangeType, Transfer } from "./types";
-import { DATA_DIR, LIQUIDITY_FILE, POOLS_FILE, TRANSFER_CHUNK_SIZE, TRANSFERS_FILE_BASE, EPOCHS, CURRENT_EPOCH } from "./constants";
-import { validateAddress } from "./constants";
+import { DATA_DIR, LIQUIDITY_FILE, POOLS_FILE, TRANSFER_CHUNK_SIZE, TRANSFERS_FILE_BASE, EPOCHS, CURRENT_EPOCH, validateAddress } from "./constants";
 import assert from "assert";
 
 /** Goldsky-hosted Cyclo subgraph endpoint for the current epoch */


### PR DESCRIPTION
## Summary
- Rename misnamed test describe block (#131)
- Rename misleading test name (#138)
- Merge duplicate `./constants` imports in scraper.ts (#123)

Closes #131, Closes #138, Closes #123

## Test plan
- [x] All 463 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)