### PR TITLE
Easy fixes 4: constants, array growth, scraper assertion

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { generateSnapshotBlocks, scaleTo18, parseEnv, isSameAddress, REWARDS_SOURCES, FACTORIES, CYTOKENS } from './config';
-import { VALID_ADDRESS_REGEX, EPOCHS, CURRENT_EPOCH } from './constants';
+import { VALID_ADDRESS_REGEX, EPOCHS, CURRENT_EPOCH, SNAPSHOT_COUNT } from './constants';
 
 describe('generateSnapshotBlocks', () => {
   
@@ -8,7 +8,7 @@ describe('generateSnapshotBlocks', () => {
   const end = 9000;
   it('should generate correct number of blocks', () => {
     const blocks = generateSnapshotBlocks('test-seed', start, end);
-    expect(blocks).toHaveLength(30);
+    expect(blocks).toHaveLength(SNAPSHOT_COUNT);
   });
 
   it('should be deterministic - same seed produces same results', () => {
@@ -35,15 +35,15 @@ describe('generateSnapshotBlocks', () => {
   });
 
   it('should not produce duplicate blocks', () => {
-    // Range of exactly 30 — pigeonhole principle means 30 unique blocks
+    // Range of exactly SNAPSHOT_COUNT — pigeonhole principle means SNAPSHOT_COUNT unique blocks
     // are possible but random draws will almost certainly collide.
-    const blocks = generateSnapshotBlocks('test-seed', 5000, 5029);
+    const blocks = generateSnapshotBlocks('test-seed', 5000, 5000 + SNAPSHOT_COUNT - 1);
     const unique = new Set(blocks);
     expect(unique.size).toBe(blocks.length);
   });
 
-  it('should error if range is less than 30', () => {
-    expect(() => generateSnapshotBlocks('test-seed', 5000, 5028)).toThrow();
+  it(`should error if range is less than ${SNAPSHOT_COUNT}`, () => {
+    expect(() => generateSnapshotBlocks('test-seed', 5000, 5000 + SNAPSHOT_COUNT - 2)).toThrow();
   });
 
   it('should generate blocks within the epoch range', () => {
@@ -56,9 +56,9 @@ describe('generateSnapshotBlocks', () => {
 
   it('should handle very large range (production scale)', () => {
     const blocks = generateSnapshotBlocks('cyclo-rewards', 52_974_045, 54_474_045);
-    expect(blocks).toHaveLength(30);
+    expect(blocks).toHaveLength(SNAPSHOT_COUNT);
     const unique = new Set(blocks);
-    expect(unique.size).toBe(30);
+    expect(unique.size).toBe(SNAPSHOT_COUNT);
     blocks.forEach(block => {
       expect(block).toBeGreaterThanOrEqual(52_974_045);
       expect(block).toBeLessThanOrEqual(54_474_045);
@@ -85,14 +85,14 @@ describe('generateSnapshotBlocks', () => {
     expect(() => generateSnapshotBlocks('test-seed', -1, 9000)).toThrow();
   });
 
-  it('should terminate quickly with minimum range of exactly 30', () => {
+  it(`should terminate quickly with minimum range of exactly ${SNAPSHOT_COUNT}`, () => {
     const start = Date.now();
-    const blocks = generateSnapshotBlocks('test-seed', 100, 129);
+    const blocks = generateSnapshotBlocks('test-seed', 100, 100 + SNAPSHOT_COUNT - 1);
     const elapsed = Date.now() - start;
-    expect(blocks).toHaveLength(30);
-    // Must contain every value in [100, 129]
-    expect(new Set(blocks).size).toBe(30);
-    for (let i = 100; i <= 129; i++) {
+    expect(blocks).toHaveLength(SNAPSHOT_COUNT);
+    // Must contain every value in [100, 100 + SNAPSHOT_COUNT - 1]
+    expect(new Set(blocks).size).toBe(SNAPSHOT_COUNT);
+    for (let i = 100; i <= 100 + SNAPSHOT_COUNT - 1; i++) {
       expect(blocks).toContain(i);
     }
     // Should complete in well under 1 second (shuffle is O(n))

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { CyToken } from "./types";
-import { validateAddress, EPOCHS, CURRENT_EPOCH } from "./constants";
+import { validateAddress, EPOCHS, CURRENT_EPOCH, SNAPSHOT_COUNT } from "./constants";
 import seedrandom from "seedrandom";
 import { shuffle } from "./shuffle";
 
@@ -71,7 +71,7 @@ export function isSameAddress(a: string, b: string): boolean {
  * @param seed - The seed phrase
  * @param start - The start block number
  * @param end - The end block number
- * @returns Sorted array of 30 unique block numbers between start and end (inclusive)
+ * @returns Sorted array of SNAPSHOT_COUNT unique block numbers between start and end (inclusive)
  */
 export function generateSnapshotBlocks(
   seed: string,
@@ -84,16 +84,16 @@ export function generateSnapshotBlocks(
   const rng = seedrandom(seed);
   const range = end - start + 1;
 
-  assert.ok(range >= 30, `Snapshot range must be at least 30, got ${range}`);
+  assert.ok(range >= SNAPSHOT_COUNT, `Snapshot range must be at least ${SNAPSHOT_COUNT}, got ${range}`);
 
-  // Build candidate array and sample 30 via Fisher-Yates shuffle
+  // Build candidate array and sample SNAPSHOT_COUNT via Fisher-Yates shuffle
   const candidates = Array.from({ length: range }, (_, i) => start + i);
   const shuffled = shuffle(candidates, rng);
-  const snapshots = shuffled.slice(0, 30).sort((a, b) => a - b);
+  const snapshots = shuffled.slice(0, SNAPSHOT_COUNT).sort((a, b) => a - b);
 
   assert.ok(
-    snapshots.length === 30,
-    `failed to generate expected number of snapshots, expected: 30, got: ${snapshots.length}`
+    snapshots.length === SNAPSHOT_COUNT,
+    `failed to generate expected number of snapshots, expected: ${SNAPSHOT_COUNT}, got: ${snapshots.length}`
   );
 
   return snapshots;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,13 +7,13 @@
 export const ONE_18 = 10n ** 18n;
 
 // Mar 2026 epoch: 300,000 tokens (18 decimals)
-export const MAR26_REWARD_POOL = 300_000_000_000_000_000_000_000n;
+export const MAR26_REWARD_POOL = 300_000n * ONE_18;
 // Feb 2026 epoch: 500,000 tokens (18 decimals)
-export const FEB26_REWARD_POOL = 500_000_000_000_000_000_000_000n;
+export const FEB26_REWARD_POOL = 500_000n * ONE_18;
 // Jan 2026 epoch: 500,000 tokens (18 decimals)
-export const JAN26_REWARD_POOL = 500_000_000_000_000_000_000_000n;
+export const JAN26_REWARD_POOL = 500_000n * ONE_18;
 // Dec 2025 epoch: 1,000,000 tokens (18 decimals) — used by diffCalculator for reconciliation
-export const DEC25_REWARD_POOL = 1_000_000_000_000_000_000_000_000n;
+export const DEC25_REWARD_POOL = 1_000_000n * ONE_18;
 
 export const REWARD_POOL = MAR26_REWARD_POOL;
 
@@ -61,6 +61,9 @@ export const TRANSFER_CHUNK_SIZE = 270000;
 
 /** Max number of transfer data files to read */
 export const TRANSFER_FILE_COUNT = 10;
+
+/** Number of snapshot blocks sampled per epoch for reward calculation */
+export const SNAPSHOT_COUNT = 30;
 
 /** 1-indexed epoch number for the current rewards run */
 export const CURRENT_EPOCH = 22;

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,10 +43,10 @@ async function main() {
 
   // Read transfers file
   console.log("Reading transfers file...");
-  const transfers: Transfer[] = [];
+  let transfers: Transfer[] = [];
   for (let i = 0; i < TRANSFER_FILE_COUNT; i++) {
     const transfersData = await readOptionalFile(`${DATA_DIR}/${TRANSFERS_FILE_BASE}${i + 1}.dat`);
-    transfers.push(...parseJsonl(transfersData, normalizeTransfer));
+    transfers = transfers.concat(parseJsonl(transfersData, normalizeTransfer));
   }
   console.log(`Found ${transfers.length} transfers`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,10 +43,10 @@ async function main() {
 
   // Read transfers file
   console.log("Reading transfers file...");
-  let transfers: Transfer[] = [];
+  const transfers: Transfer[] = [];
   for (let i = 0; i < TRANSFER_FILE_COUNT; i++) {
     const transfersData = await readOptionalFile(`${DATA_DIR}/${TRANSFERS_FILE_BASE}${i + 1}.dat`);
-    transfers = [...transfers, ...parseJsonl(transfersData, normalizeTransfer)];
+    transfers.push(...parseJsonl(transfersData, normalizeTransfer));
   }
   console.log(`Found ${transfers.length} transfers`);
 

--- a/src/rewardsOutput.test.ts
+++ b/src/rewardsOutput.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
-import { REWARD_POOL, VALID_ADDRESS_REGEX, REWARDS_CSV_COLUMN_HEADER_ADDRESS, REWARDS_CSV_COLUMN_HEADER_REWARD, EPOCHS, CURRENT_EPOCH } from './constants';
+import { REWARD_POOL, VALID_ADDRESS_REGEX, REWARDS_CSV_COLUMN_HEADER_ADDRESS, REWARDS_CSV_COLUMN_HEADER_REWARD, EPOCHS, CURRENT_EPOCH, SNAPSHOT_COUNT } from './constants';
 import { REWARDS_SOURCES, FACTORIES, CYTOKENS } from './config';
 
 const epoch = EPOCHS[CURRENT_EPOCH - 1];
@@ -123,8 +123,8 @@ describe('current epoch balances output', () => {
   const rewardAddresses = new Set(rewardEntries.map(r => r.address));
 
   it('has correct number of columns (address + 35 per token + total_rewards)', () => {
-    // address + (30 snapshots + average + penalty + bounty + final + rewards) × 3 tokens + total_rewards
-    const expected = 1 + (35 * CYTOKENS.length) + 1;
+    // address + (SNAPSHOT_COUNT snapshots + average + penalty + bounty + final + rewards) × 3 tokens + total_rewards
+    const expected = 1 + ((SNAPSHOT_COUNT + 5) * CYTOKENS.length) + 1;
     expect(columns.length).toBe(expected);
   });
 
@@ -136,9 +136,9 @@ describe('current epoch balances output', () => {
     expect(columns[columns.length - 1]).toBe('total_rewards');
   });
 
-  it('has 30 snapshot columns per token', () => {
+  it(`has ${SNAPSHOT_COUNT} snapshot columns per token`, () => {
     for (const token of CYTOKENS) {
-      for (let i = 1; i <= 30; i++) {
+      for (let i = 1; i <= SNAPSHOT_COUNT; i++) {
         expect(columns).toContain(`${token.name}_snapshot${i}`);
       }
     }
@@ -174,15 +174,15 @@ describe('balances arithmetic consistency', () => {
     const address = parts[0];
     const tokenData: Record<string, { snapshots: bigint[]; average: bigint; penalty: bigint; bounty: bigint; final: bigint; rewards: bigint }> = {};
     for (let t = 0; t < CYTOKENS.length; t++) {
-      const base = 1 + t * 35;
-      const snapshots = parts.slice(base, base + 30).map(BigInt);
+      const base = 1 + t * (SNAPSHOT_COUNT + 5);
+      const snapshots = parts.slice(base, base + SNAPSHOT_COUNT).map(BigInt);
       tokenData[CYTOKENS[t].name] = {
         snapshots,
-        average: BigInt(parts[base + 30]),
-        penalty: BigInt(parts[base + 31]),
-        bounty: BigInt(parts[base + 32]),
-        final: BigInt(parts[base + 33]),
-        rewards: BigInt(parts[base + 34]),
+        average: BigInt(parts[base + SNAPSHOT_COUNT]),
+        penalty: BigInt(parts[base + SNAPSHOT_COUNT + 1]),
+        bounty: BigInt(parts[base + SNAPSHOT_COUNT + 2]),
+        final: BigInt(parts[base + SNAPSHOT_COUNT + 3]),
+        rewards: BigInt(parts[base + SNAPSHOT_COUNT + 4]),
       };
     }
     return { address, tokenData, totalRewards: BigInt(parts[parts.length - 1]) };
@@ -190,12 +190,12 @@ describe('balances arithmetic consistency', () => {
 
   const allRows = lines.slice(1).map(parseRow);
 
-  it('average equals mean of 30 snapshots for all accounts', () => {
+  it(`average equals mean of ${SNAPSHOT_COUNT} snapshots for all accounts`, () => {
     for (const row of allRows) {
       for (const token of CYTOKENS) {
         const td = row.tokenData[token.name];
         const sum = td.snapshots.reduce((s, v) => s + v, 0n);
-        const expectedAvg = sum / 30n;
+        const expectedAvg = sum / BigInt(SNAPSHOT_COUNT);
         expect(td.average).toBe(expectedAvg);
       }
     }
@@ -249,8 +249,8 @@ describe('snapshot blocks', () => {
   const data = readFileSync(SNAPSHOTS_FILE, 'utf8');
   const blocks = data.split('\n').filter(Boolean).map(Number);
 
-  it('has exactly 30 snapshot blocks', () => {
-    expect(blocks.length).toBe(30);
+  it(`has exactly ${SNAPSHOT_COUNT} snapshot blocks`, () => {
+    expect(blocks.length).toBe(SNAPSHOT_COUNT);
   });
 
   it('all blocks are within epoch range', () => {

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -6,7 +6,7 @@
 import { request, gql } from "graphql-request";
 import { writeFile } from "fs/promises";
 import { LiquidityChange, LiquidityChangeType, Transfer } from "./types";
-import { DATA_DIR, LIQUIDITY_FILE, POOLS_FILE, TRANSFER_CHUNK_SIZE, TRANSFERS_FILE_BASE, EPOCHS, CURRENT_EPOCH, validateAddress } from "./constants";
+import { DATA_DIR, LIQUIDITY_FILE, POOLS_FILE, TRANSFER_CHUNK_SIZE, TRANSFER_FILE_COUNT, TRANSFERS_FILE_BASE, EPOCHS, CURRENT_EPOCH, validateAddress } from "./constants";
 import assert from "assert";
 
 /** Goldsky-hosted Cyclo subgraph endpoint for the current epoch */
@@ -211,6 +211,7 @@ async function scrapeTransfers() {
     // if the scraper fails mid-run, previously fetched data is preserved on disk.
     // Files are split at TRANSFER_CHUNK_SIZE lines to stay under GitHub's 100MB file size limit.
     const fileCount = Math.ceil(transfers.length / TRANSFER_CHUNK_SIZE);
+    assert(fileCount <= TRANSFER_FILE_COUNT, `Transfer data requires ${fileCount} files but TRANSFER_FILE_COUNT is ${TRANSFER_FILE_COUNT} — increase TRANSFER_FILE_COUNT to avoid data loss`);
     for (let i = 0; i < fileCount; i++) {
       await writeFile(
         `${DATA_DIR}/${TRANSFERS_FILE_BASE}${i + 1}.dat`,


### PR DESCRIPTION
## Summary
- Extract `SNAPSHOT_COUNT` constant to replace magic number `30` across config, tests, and output validation (Fixes #100)
- Derive reward pool constants from `token_count * ONE_18` instead of opaque literals (Fixes #104, Fixes #68)
- Replace quadratic `[...spread]` with `push()` in transfer loading loop (Fixes #106)
- Assert `fileCount <= TRANSFER_FILE_COUNT` in scraper to prevent silent data loss (Fixes #105)

## Test plan
- [x] All existing tests pass
- [x] Tests updated to use `SNAPSHOT_COUNT` constant
- [x] Reward pool values unchanged (derivation produces same BigInt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)