### PR TITLE
faster transfer file loading (no quadratic merge)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,14 @@ async function main() {
   console.log("Starting processor...");
   console.log(`Snapshot blocks: ${START_SNAPSHOT}, ${END_SNAPSHOT}`);
 
-  // Read transfers file
+  // Read transfers file — append per file with push to avoid quadratic copying from [...prev, ...batch]
   console.log("Reading transfers file...");
-  let transfers: Transfer[] = [];
+  const transfers: Transfer[] = [];
   for (let i = 0; i < TRANSFER_FILE_COUNT; i++) {
     const transfersData = await readOptionalFile(`${DATA_DIR}/${TRANSFERS_FILE_BASE}${i + 1}.dat`);
-    transfers = [...transfers, ...parseJsonl(transfersData, normalizeTransfer)];
+    for (const t of parseJsonl(transfersData, normalizeTransfer)) {
+      transfers.push(t);
+    }
   }
   console.log(`Found ${transfers.length} transfers`);
 


### PR DESCRIPTION
## what changed
the main pipeline was building the full transfers array with \	ransfers = [...transfers, ...batch]\ for each of up to 10 files. that copies every row seen so far on every file, so work and peak memory scale quadratically in the total row count (same pattern as #106 fixed for the scraper loop).

now each file appends with \push\ in a tight loop, so loading stays linear in the number of transfers.

## test plan
- no behavior change: same order and contents in \	ransfers\ as before
- run \
pm test\ (or vitest) in an environment with \RPC_URL\ set if you run the full suite

