### PR TITLE
update scraper subgraph to 2026-04-09-ae4f

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -11,7 +11,7 @@ import assert from "assert";
 
 /** Goldsky-hosted Cyclo subgraph endpoint for the current epoch */
 const SUBGRAPH_URL =
-  "https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-06-99d3/gn";
+  "https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-09-ae4f/gn";
 const BATCH_SIZE = 1000;
 
 const epoch = EPOCHS[CURRENT_EPOCH - 1];

--- a/src/subgraphIntegrity.test.ts
+++ b/src/subgraphIntegrity.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests that the subgraph's LP balance tracking matches the rewards processor's
+ * computation from raw liquidity events. Failures here indicate the subgraph
+ * is not crediting LP deposits correctly.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { EPOCHS, CURRENT_EPOCH } from "./constants";
+
+const SUBGRAPH_URL =
+  "https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-06-99d3/gn";
+
+const CYSFLR = "0x19831cfb53a0dbead9866c43557c1d48dff76567";
+
+interface LiquidityEvent {
+  owner: string;
+  tokenAddress: string;
+  blockNumber: string;
+  depositedBalanceChange: string;
+  changeType: string;
+}
+
+function computeLpBalancesFromEvents(
+  tokenAddress: string,
+  maxBlock: number,
+): Map<string, bigint> {
+  const data = readFileSync("./data/liquidity.dat", "utf8");
+  const balances = new Map<string, bigint>();
+  for (const line of data.split("\n").filter(Boolean)) {
+    const event: LiquidityEvent = JSON.parse(line);
+    if (event.tokenAddress !== tokenAddress) continue;
+    if (parseInt(event.blockNumber) > maxBlock) continue;
+    const prev = balances.get(event.owner) ?? 0n;
+    balances.set(event.owner, prev + BigInt(event.depositedBalanceChange));
+  }
+  return balances;
+}
+
+async function querySubgraphLpBalances(
+  tokenAddress: string,
+): Promise<Map<string, bigint>> {
+  const response = await fetch(SUBGRAPH_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query: `{ vaultBalances(where: {vault: "${tokenAddress}"}, first: 1000) { owner { id } lpBalance } }`,
+    }),
+  });
+  const data = await response.json();
+  const balances = new Map<string, bigint>();
+  for (const vb of data.data.vaultBalances) {
+    const lp = BigInt(vb.lpBalance);
+    if (lp !== 0n) {
+      balances.set(vb.owner.id, lp);
+    }
+  }
+  return balances;
+}
+
+describe("subgraph lpBalance matches rewards processor", () => {
+  const epoch = EPOCHS[CURRENT_EPOCH - 1];
+
+  it("cysFLR lpBalance matches for all accounts with LP positions", async () => {
+    const expected = computeLpBalancesFromEvents(CYSFLR, epoch.endBlock);
+    const actual = await querySubgraphLpBalances(CYSFLR);
+
+    const accountsWithLp = [...expected.entries()].filter(([, v]) => v > 0n);
+    const mismatches: Array<{ address: string; expected: bigint; actual: bigint }> = [];
+
+    for (const [address, expectedLp] of accountsWithLp) {
+      const actualLp = actual.get(address) ?? 0n;
+      if (actualLp !== expectedLp) {
+        mismatches.push({ address, expected: expectedLp, actual: actualLp });
+      }
+    }
+
+    if (mismatches.length > 0) {
+      const details = mismatches
+        .sort((a, b) => Number(b.expected - a.expected))
+        .slice(0, 10)
+        .map((m) => `  ${m.address}  expected=${m.expected}  actual=${m.actual}`)
+        .join("\n");
+      throw new Error(
+        `${mismatches.length} of ${accountsWithLp.length} accounts have wrong cysFLR lpBalance in subgraph:\n${details}`
+      );
+    }
+  }, 30_000);
+});

--- a/src/subgraphSelfConsistency.test.ts
+++ b/src/subgraphSelfConsistency.test.ts
@@ -124,5 +124,32 @@ describe("subgraph self-consistency: lpBalance vs liquidity change events", () =
       );
     }
   }, 60_000);
+
+  it(`${token.name} no vaultBalance has lpBalance > 0 without matching events`, async () => {
+    const fromEvents = await computeLpBalancesFromSubgraphEvents(token.address);
+    const vaultBalances = await querySubgraphLpBalances(token.address);
+
+    const mismatches: Array<{ address: string; fromEvents: bigint; fromVaultBalance: bigint }> = [];
+
+    for (const [address, vb] of vaultBalances) {
+      const vaultLp = BigInt(vb.lpBalance);
+      if (vaultLp <= 0n) continue;
+      const eventLp = fromEvents.get(address) ?? 0n;
+      if (eventLp !== vaultLp) {
+        mismatches.push({ address, fromEvents: eventLp, fromVaultBalance: vaultLp });
+      }
+    }
+
+    if (mismatches.length > 0) {
+      const details = mismatches
+        .sort((a, b) => Number(b.fromVaultBalance - a.fromVaultBalance))
+        .slice(0, 10)
+        .map((m) => `  ${m.address}  events=${m.fromEvents}  vaultBalance=${m.fromVaultBalance}`)
+        .join("\n");
+      throw new Error(
+        `${mismatches.length} accounts have ${token.name} lpBalance > 0 without matching events:\n${details}`
+      );
+    }
+  }, 60_000);
   }
 });

--- a/src/subgraphSelfConsistency.test.ts
+++ b/src/subgraphSelfConsistency.test.ts
@@ -151,5 +151,34 @@ describe("subgraph self-consistency: lpBalance vs liquidity change events", () =
       );
     }
   }, 60_000);
+
+  it(`${token.name} balance equals min(clamp0(boughtCap), clamp0(lpBalance))`, async () => {
+    const vaultBalances = await querySubgraphLpBalances(token.address);
+
+    const mismatches: Array<{ address: string; expected: bigint; actual: bigint }> = [];
+
+    for (const [address, vb] of vaultBalances) {
+      const cap = BigInt(vb.boughtCap);
+      const lp = BigInt(vb.lpBalance);
+      const clampedCap = cap < 0n ? 0n : cap;
+      const clampedLp = lp < 0n ? 0n : lp;
+      const expected = clampedCap < clampedLp ? clampedCap : clampedLp;
+      const actual = BigInt(vb.balance);
+      if (actual !== expected) {
+        mismatches.push({ address, expected, actual });
+      }
+    }
+
+    if (mismatches.length > 0) {
+      const details = mismatches
+        .sort((a, b) => Number(b.expected - a.expected))
+        .slice(0, 10)
+        .map((m) => `  ${m.address}  expected=${m.expected}  actual=${m.actual}`)
+        .join("\n");
+      throw new Error(
+        `${mismatches.length} accounts have wrong ${token.name} balance:\n${details}`
+      );
+    }
+  }, 60_000);
   }
 });

--- a/src/subgraphSelfConsistency.test.ts
+++ b/src/subgraphSelfConsistency.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests that the subgraph's VaultBalance.lpBalance matches the sum of its own
+ * LiquidityChange events. Both sides are queried at HEAD, so there is no
+ * time-mismatch. Failures here indicate the subgraph is not crediting LP
+ * deposits/withdrawals correctly in VaultBalance.lpBalance.
+ */
+import { describe, it, expect } from "vitest";
+
+const SUBGRAPH_URL =
+  "https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-09-ae4f/gn";
+
+const CYSFLR = "0x19831cfb53a0dbead9866c43557c1d48dff76567";
+
+interface LiquidityChangeResult {
+  owner: { id: string };
+  depositedBalanceChange: string;
+}
+
+interface VaultBalanceResult {
+  owner: { id: string };
+  lpBalance: string;
+}
+
+async function queryAllPaginated<T>(
+  entityName: string,
+  fields: string,
+  filter: string,
+): Promise<T[]> {
+  const results: T[] = [];
+  let skip = 0;
+  const first = 1000;
+  while (true) {
+    const response = await fetch(SUBGRAPH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: `{ ${entityName}(where: {${filter}}, first: ${first}, skip: ${skip}, orderBy: blockNumber, orderDirection: asc) { ${fields} } }`,
+      }),
+    });
+    const data = await response.json();
+    const batch = data.data[entityName] as T[];
+    results.push(...batch);
+    if (batch.length < first) break;
+    skip += first;
+  }
+  return results;
+}
+
+async function computeLpBalancesFromSubgraphEvents(
+  tokenAddress: string,
+): Promise<Map<string, bigint>> {
+  const balances = new Map<string, bigint>();
+
+  const v2Changes = await queryAllPaginated<LiquidityChangeResult>(
+    "liquidityV2Changes",
+    "owner { id } depositedBalanceChange",
+    `tokenAddress: "${tokenAddress}"`,
+  );
+  const v3Changes = await queryAllPaginated<LiquidityChangeResult>(
+    "liquidityV3Changes",
+    "owner { id } depositedBalanceChange",
+    `tokenAddress: "${tokenAddress}"`,
+  );
+
+  for (const event of [...v2Changes, ...v3Changes]) {
+    const prev = balances.get(event.owner.id) ?? 0n;
+    balances.set(event.owner.id, prev + BigInt(event.depositedBalanceChange));
+  }
+  return balances;
+}
+
+async function querySubgraphLpBalances(
+  tokenAddress: string,
+): Promise<Map<string, bigint>> {
+  const balances = new Map<string, bigint>();
+  let lastId = "";
+  const first = 1000;
+  while (true) {
+    const idFilter = lastId ? `, id_gt: "${lastId}"` : "";
+    const response = await fetch(SUBGRAPH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: `{ vaultBalances(where: {vault: "${tokenAddress}"${idFilter}}, first: ${first}, orderBy: id, orderDirection: asc) { id owner { id } lpBalance } }`,
+      }),
+    });
+    const data = await response.json();
+    const batch = data.data.vaultBalances as (VaultBalanceResult & { id: string })[];
+    for (const vb of batch) {
+      balances.set(vb.owner.id, BigInt(vb.lpBalance));
+    }
+    if (batch.length < first) break;
+    lastId = batch[batch.length - 1].id;
+  }
+  return balances;
+}
+
+describe("subgraph self-consistency: lpBalance vs liquidity change events", () => {
+  it("cysFLR vaultBalance.lpBalance matches sum of liquidityChange events", async () => {
+    const fromEvents = await computeLpBalancesFromSubgraphEvents(CYSFLR);
+    const fromVaultBalances = await querySubgraphLpBalances(CYSFLR);
+
+    const accountsWithLp = [...fromEvents.entries()].filter(([, v]) => v > 0n);
+    const mismatches: Array<{ address: string; fromEvents: bigint; fromVaultBalance: bigint }> = [];
+
+    for (const [address, eventLp] of accountsWithLp) {
+      const vaultLp = fromVaultBalances.get(address) ?? 0n;
+      if (vaultLp !== eventLp) {
+        mismatches.push({ address, fromEvents: eventLp, fromVaultBalance: vaultLp });
+      }
+    }
+
+    if (mismatches.length > 0) {
+      const details = mismatches
+        .sort((a, b) => Number(b.fromEvents - a.fromEvents))
+        .slice(0, 10)
+        .map((m) => `  ${m.address}  events=${m.fromEvents}  vaultBalance=${m.fromVaultBalance}`)
+        .join("\n");
+      throw new Error(
+        `${mismatches.length} of ${accountsWithLp.length} accounts have inconsistent cysFLR lpBalance:\n${details}`
+      );
+    }
+  }, 60_000);
+});

--- a/src/subgraphSelfConsistency.test.ts
+++ b/src/subgraphSelfConsistency.test.ts
@@ -5,11 +5,10 @@
  * deposits/withdrawals correctly in VaultBalance.lpBalance.
  */
 import { describe, it, expect } from "vitest";
+import { CYTOKENS } from "./config";
 
 const SUBGRAPH_URL =
   "https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-09-ae4f/gn";
-
-const CYSFLR = "0x19831cfb53a0dbead9866c43557c1d48dff76567";
 
 interface LiquidityChangeResult {
   owner: { id: string };
@@ -19,6 +18,8 @@ interface LiquidityChangeResult {
 interface VaultBalanceResult {
   owner: { id: string };
   lpBalance: string;
+  boughtCap: string;
+  balance: string;
 }
 
 async function queryAllPaginated<T>(
@@ -71,8 +72,8 @@ async function computeLpBalancesFromSubgraphEvents(
 
 async function querySubgraphLpBalances(
   tokenAddress: string,
-): Promise<Map<string, bigint>> {
-  const balances = new Map<string, bigint>();
+): Promise<Map<string, VaultBalanceResult>> {
+  const balances = new Map<string, VaultBalanceResult>();
   let lastId = "";
   const first = 1000;
   while (true) {
@@ -81,13 +82,13 @@ async function querySubgraphLpBalances(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        query: `{ vaultBalances(where: {vault: "${tokenAddress}"${idFilter}}, first: ${first}, orderBy: id, orderDirection: asc) { id owner { id } lpBalance } }`,
+        query: `{ vaultBalances(where: {vault: "${tokenAddress}"${idFilter}}, first: ${first}, orderBy: id, orderDirection: asc) { id owner { id } lpBalance boughtCap balance } }`,
       }),
     });
     const data = await response.json();
     const batch = data.data.vaultBalances as (VaultBalanceResult & { id: string })[];
     for (const vb of batch) {
-      balances.set(vb.owner.id, BigInt(vb.lpBalance));
+      balances.set(vb.owner.id, vb);
     }
     if (batch.length < first) break;
     lastId = batch[batch.length - 1].id;
@@ -96,15 +97,17 @@ async function querySubgraphLpBalances(
 }
 
 describe("subgraph self-consistency: lpBalance vs liquidity change events", () => {
-  it("cysFLR vaultBalance.lpBalance matches sum of liquidityChange events", async () => {
-    const fromEvents = await computeLpBalancesFromSubgraphEvents(CYSFLR);
-    const fromVaultBalances = await querySubgraphLpBalances(CYSFLR);
+  for (const token of CYTOKENS) {
+  it(`${token.name} vaultBalance.lpBalance matches sum of liquidityChange events`, async () => {
+    const fromEvents = await computeLpBalancesFromSubgraphEvents(token.address);
+    const fromVaultBalances = await querySubgraphLpBalances(token.address);
 
     const accountsWithLp = [...fromEvents.entries()].filter(([, v]) => v > 0n);
     const mismatches: Array<{ address: string; fromEvents: bigint; fromVaultBalance: bigint }> = [];
 
     for (const [address, eventLp] of accountsWithLp) {
-      const vaultLp = fromVaultBalances.get(address) ?? 0n;
+      const vb = fromVaultBalances.get(address);
+      const vaultLp = vb ? BigInt(vb.lpBalance) : 0n;
       if (vaultLp !== eventLp) {
         mismatches.push({ address, fromEvents: eventLp, fromVaultBalance: vaultLp });
       }
@@ -117,8 +120,9 @@ describe("subgraph self-consistency: lpBalance vs liquidity change events", () =
         .map((m) => `  ${m.address}  events=${m.fromEvents}  vaultBalance=${m.fromVaultBalance}`)
         .join("\n");
       throw new Error(
-        `${mismatches.length} of ${accountsWithLp.length} accounts have inconsistent cysFLR lpBalance:\n${details}`
+        `${mismatches.length} of ${accountsWithLp.length} accounts have inconsistent ${token.name} lpBalance:\n${details}`
       );
     }
   }, 60_000);
+  }
 });


### PR DESCRIPTION
## Summary
- Switch scraper to `ae4f` subgraph which includes V3 cy/cy pool deposit matching fix

## Test plan
- [x] Subgraph verified as 100% synced
- [x] Self-consistency tests confirm same profile as `99d3` (1 known V2 mismatch)
- [ ] CI git-clean passes with rescrape

🤖 Generated with [Claude Code](https://claude.com/claude-code)