### PR TITLE
Easy fixes 5: deduplicate AccountBalance, reuse updateSnapshots, standardize assert

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -78,20 +78,20 @@ export function generateSnapshotBlocks(
   start: number,
   end: number,
 ): number[] {
-  assert.ok(seed.length > 0, "Seed must not be empty");
-  assert.ok(Number.isInteger(start) && start >= 0, `start must be a non-negative integer, got ${start}`);
-  assert.ok(Number.isInteger(end) && end >= 0, `end must be a non-negative integer, got ${end}`);
+  assert(seed.length > 0, "Seed must not be empty");
+  assert(Number.isInteger(start) && start >= 0, `start must be a non-negative integer, got ${start}`);
+  assert(Number.isInteger(end) && end >= 0, `end must be a non-negative integer, got ${end}`);
   const rng = seedrandom(seed);
   const range = end - start + 1;
 
-  assert.ok(range >= SNAPSHOT_COUNT, `Snapshot range must be at least ${SNAPSHOT_COUNT}, got ${range}`);
+  assert(range >= SNAPSHOT_COUNT, `Snapshot range must be at least ${SNAPSHOT_COUNT}, got ${range}`);
 
   // Build candidate array and sample SNAPSHOT_COUNT via Fisher-Yates shuffle
   const candidates = Array.from({ length: range }, (_, i) => start + i);
   const shuffled = shuffle(candidates, rng);
   const snapshots = shuffled.slice(0, SNAPSHOT_COUNT).sort((a, b) => a - b);
 
-  assert.ok(
+  assert(
     snapshots.length === SNAPSHOT_COUNT,
     `failed to generate expected number of snapshots, expected: ${SNAPSHOT_COUNT}, got: ${snapshots.length}`
   );

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -564,16 +564,12 @@ export class Processor {
     // Update LP balance from liquidity events
     ownerBalance.lpBalance += depositedBalanceChange;
 
-    // Update snapshot balances: eligible = min(boughtCap, lpBalance), clamped to 0
-    const cap = clamp0(ownerBalance.boughtCap);
-    const lp = clamp0(ownerBalance.lpBalance);
-    const value = cap < lp ? cap : lp;
-    for (let i = 0; i < this.snapshots.length; i++) {
-      if (liquidityChangeEvent.blockNumber <= this.snapshots[i]) {
-        ownerBalance.netBalanceAtSnapshots[i] = value;
+    this.updateSnapshots(ownerBalance, liquidityChangeEvent.blockNumber);
 
-        // update lp v3 tracklist
-        if (liquidityChangeEvent.__typename === "LiquidityV3Change") {
+    // update lp v3 tracklist
+    if (liquidityChangeEvent.__typename === "LiquidityV3Change") {
+      for (let i = 0; i < this.snapshots.length; i++) {
+        if (liquidityChangeEvent.blockNumber <= this.snapshots[i]) {
           const id = lpV3PositionId(
             liquidityChangeEvent.tokenAddress,
             liquidityChangeEvent.owner,

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -31,6 +31,17 @@ function clamp0(val: bigint): bigint {
   return val < 0n ? 0n : val;
 }
 
+/** Create a fresh zero-initialized AccountBalance for a given number of snapshots */
+function newAccountBalance(snapshotCount: number): AccountBalance {
+  return {
+    transfersInFromApproved: 0n,
+    transfersOut: 0n,
+    netBalanceAtSnapshots: new Array(snapshotCount).fill(0n),
+    boughtCap: 0n,
+    lpBalance: 0n,
+  };
+}
+
 /** Build a V3 LP position ID from token, owner, pool, and tokenId */
 function lpV3PositionId(token: string, owner: string, pool: string, tokenId: string): string {
   return `${token}-${owner}-${pool}-${tokenId}`;
@@ -190,22 +201,10 @@ export class Processor {
 
     // Initialize balances if needed
     if (!accountBalances.has(transfer.to)) {
-      accountBalances.set(transfer.to, {
-        transfersInFromApproved: 0n,
-        transfersOut: 0n,
-        netBalanceAtSnapshots: new Array(this.snapshots.length).fill(0n),
-        boughtCap: 0n,
-        lpBalance: 0n,
-      });
+      accountBalances.set(transfer.to, newAccountBalance(this.snapshots.length));
     }
     if (!accountBalances.has(transfer.from)) {
-      accountBalances.set(transfer.from, {
-        transfersInFromApproved: 0n,
-        transfersOut: 0n,
-        netBalanceAtSnapshots: new Array(this.snapshots.length).fill(0n),
-        boughtCap: 0n,
-        lpBalance: 0n,
-      });
+      accountBalances.set(transfer.from, newAccountBalance(this.snapshots.length));
     }
 
     // LP deposits and withdrawals are neutral to the bought cap —
@@ -558,13 +557,7 @@ export class Processor {
 
     // Initialize balances if needed
     if (!accountBalances.has(liquidityChangeEvent.owner)) {
-      accountBalances.set(liquidityChangeEvent.owner, {
-        transfersInFromApproved: 0n,
-        transfersOut: 0n,
-        netBalanceAtSnapshots: new Array(this.snapshots.length).fill(0n),
-        boughtCap: 0n,
-        lpBalance: 0n,
-      });
+      accountBalances.set(liquidityChangeEvent.owner, newAccountBalance(this.snapshots.length));
     }
 
     const ownerBalance = accountBalances.get(liquidityChangeEvent.owner)!;


### PR DESCRIPTION
## Summary
- Extract `newAccountBalance()` helper to deduplicate init literal (Fixes #118)
- Reuse `updateSnapshots()` in `processLiquidityPositions` instead of inline copy (Fixes #119)
- Standardize on `assert()` instead of `assert.ok()` (Fixes #101)

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)