### PR TITLE
Easy fixes 6: retry constants, camelCase locals, dedup calculations

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,12 @@ export const BOUNTY_PERCENT = 10n;
 /** Base delay in ms for exponential backoff on RPC retries */
 export const RETRY_BASE_DELAY_MS = 500;
 
+/** Max retry attempts for tick multicall queries */
+export const TICK_RETRY_ATTEMPTS = 3;
+
+/** Fixed delay in ms between tick multicall retries */
+export const TICK_RETRY_DELAY_MS = 10_000;
+
 /** Directory for scraped data files */
 export const DATA_DIR = "data";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,22 +24,22 @@ config();
  * processes all events through the Processor, and writes output CSVs.
  */
 async function main() {
-  const { seed: SEED, startSnapshot: START_SNAPSHOT, endSnapshot: END_SNAPSHOT } = parseEnv();
+  const { seed, startSnapshot, endSnapshot } = parseEnv();
 
   // generate snapshot blocks
-  const SNAPSHOTS = generateSnapshotBlocks(SEED, START_SNAPSHOT, END_SNAPSHOT);
+  const snapshots = generateSnapshotBlocks(seed, startSnapshot, endSnapshot);
 
   // Create output directory if it doesn't exist
   await mkdir(OUTPUT_DIR, { recursive: true });
 
   // write generated snapshots
   await writeFile(
-    `${OUTPUT_DIR}/snapshots-${START_SNAPSHOT}-${END_SNAPSHOT}.txt`,
-    SNAPSHOTS.join("\n")
+    `${OUTPUT_DIR}/snapshots-${startSnapshot}-${endSnapshot}.txt`,
+    snapshots.join("\n")
   );
 
   console.log("Starting processor...");
-  console.log(`Snapshot blocks: ${START_SNAPSHOT}, ${END_SNAPSHOT}`);
+  console.log(`Snapshot blocks: ${startSnapshot}, ${endSnapshot}`);
 
   // Read transfers file — append per file with push to avoid quadratic copying
   console.log("Reading transfers file...");
@@ -73,7 +73,7 @@ async function main() {
   // Setup processor with snapshot blocks and blocklist
   console.log("Setting up processor...");
   const client = createPublicClient({ chain: flare, transport: http(RPC_URL) });
-  const processor = new Processor(SNAPSHOTS, reports, client, pools);
+  const processor = new Processor(snapshots, reports, client, pools);
 
   // Organize liquidity changes
   console.log(`Organizing ${liquidities.length} liquidity change events...`);
@@ -142,12 +142,12 @@ async function main() {
   }
   const totalRewardsPerAddress = aggregateRewardsPerAddress(rewardsPerToken);
   const addresses = sortAddressesByReward(totalRewardsPerAddress);
-  const balancesOutput = formatBalancesCsv(addresses, CYTOKENS, SNAPSHOTS, balances, rewardsPerToken, totalRewardsPerAddress);
+  const balancesOutput = formatBalancesCsv(addresses, CYTOKENS, snapshots, balances, rewardsPerToken, totalRewardsPerAddress);
   await writeFile(
-    `${OUTPUT_DIR}/balances-${START_SNAPSHOT}-${END_SNAPSHOT}.csv`,
+    `${OUTPUT_DIR}/balances-${startSnapshot}-${endSnapshot}.csv`,
     balancesOutput.join("\n")
   );
-  console.log(`Wrote ${addresses.length} balances to ${OUTPUT_DIR}/balances-${START_SNAPSHOT}-${END_SNAPSHOT}.csv`);
+  console.log(`Wrote ${addresses.length} balances to ${OUTPUT_DIR}/balances-${startSnapshot}-${endSnapshot}.csv`);
 
   // Calculate and write rewards
   console.log("Calculating rewards...");
@@ -156,10 +156,10 @@ async function main() {
   const rewardedAddresses = filterZeroRewards(addresses, totalRewardsPerAddress);
   const rewardsOutput = formatRewardsCsv(rewardedAddresses, totalRewardsPerAddress);
   await writeFile(
-    `${OUTPUT_DIR}/rewards-${START_SNAPSHOT}-${END_SNAPSHOT}.csv`,
+    `${OUTPUT_DIR}/rewards-${startSnapshot}-${endSnapshot}.csv`,
     rewardsOutput.join("\n")
   );
-  console.log(`Wrote ${rewardedAddresses.length} rewards to ${OUTPUT_DIR}/rewards-${START_SNAPSHOT}-${END_SNAPSHOT}.csv`);
+  console.log(`Wrote ${rewardedAddresses.length} rewards to ${OUTPUT_DIR}/rewards-${startSnapshot}-${endSnapshot}.csv`);
 
   // Verify total rewards equals reward pool
   const totalRewards = Array.from(totalRewardsPerAddress.values()).reduce(

--- a/src/liquidity.ts
+++ b/src/liquidity.ts
@@ -3,6 +3,7 @@
  */
 
 import { PublicClient } from "viem";
+import { TICK_RETRY_ATTEMPTS, TICK_RETRY_DELAY_MS } from "./constants";
 
 /** Multicall3 canonical deployment address (same on all EVM chains) */
 export const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11" as const;
@@ -120,14 +121,12 @@ export async function getPoolsTick(
     if (!Number.isInteger(blockNumber) || blockNumber < 0) {
         throw new Error(`Invalid blockNumber: ${blockNumber}`);
     }
-    const MAX_ATTEMPTS = 3;
-    const RETRY_DELAY_MS = 10_000;
-    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+    for (let i = 0; i < TICK_RETRY_ATTEMPTS; i++) {
         try {
             return await getPoolsTickMulticall(client, pools, BigInt(blockNumber))
         } catch (error) {
-            if (i >= MAX_ATTEMPTS - 1) throw error;
-            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+            if (i >= TICK_RETRY_ATTEMPTS - 1) throw error;
+            await new Promise((resolve) => setTimeout(resolve, TICK_RETRY_DELAY_MS));
         }
     }
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -405,6 +405,7 @@ export class Processor {
    * @returns CyToken definitions that have at least one account with balance
    */
   getTokensWithBalance(balances: EligibleBalances, totalBalances?: Map<string, bigint>): CyToken[] {
+    const tokensWithBalance: CyToken[] = [];
     const totals = totalBalances ?? this.calculateTotalEligibleBalances(balances);
     for (const token of CYTOKENS) {
       if (totals.get(token.address)! > 0n) {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -404,11 +404,10 @@ export class Processor {
    * @param balances - Eligible balances from getEligibleBalances()
    * @returns CyToken definitions that have at least one account with balance
    */
-  getTokensWithBalance(balances: EligibleBalances): CyToken[] {
-    const tokensWithBalance: CyToken[] = [];
-    const totalBalances = this.calculateTotalEligibleBalances(balances);
+  getTokensWithBalance(balances: EligibleBalances, totalBalances?: Map<string, bigint>): CyToken[] {
+    const totals = totalBalances ?? this.calculateTotalEligibleBalances(balances);
     for (const token of CYTOKENS) {
-      if (totalBalances.get(token.address)! > 0n) {
+      if (totals.get(token.address)! > 0n) {
         tokensWithBalance.push(token);
       }
     }
@@ -424,14 +423,15 @@ export class Processor {
    */
   calculateRewardsPoolsPerToken(
     balances: EligibleBalances,
-    rewardPool: bigint
+    rewardPool: bigint,
+    totalBalances?: Map<string, bigint>,
   ): Map<string, bigint> {
-    const totalBalances = this.calculateTotalEligibleBalances(balances);
+    const totals = totalBalances ?? this.calculateTotalEligibleBalances(balances);
 
     // we only want to calculate rewards for tokens that have a balance
-    const tokensWithBalance = this.getTokensWithBalance(balances);
+    const tokensWithBalance = this.getTokensWithBalance(balances, totals);
 
-    const sumOfAllBalances = Array.from(totalBalances.values()).reduce(
+    const sumOfAllBalances = Array.from(totals.values()).reduce(
       (acc, balance) => acc + balance,
       0n
     );
@@ -441,7 +441,7 @@ export class Processor {
     for (const token of tokensWithBalance) {
       const tokenInverseFraction =
         (sumOfAllBalances * ONE_18) /
-        totalBalances.get(token.address)!;
+        totals.get(token.address)!;
       tokenInverseFractions.set(
         token.address,
         tokenInverseFraction
@@ -475,15 +475,15 @@ export class Processor {
    */
   async calculateRewards(rewardPool: bigint): Promise<RewardsPerToken> {
     const balances = await this.getEligibleBalances();
+    const totalBalances = this.calculateTotalEligibleBalances(balances);
 
     const totalRewardsPerToken = this.calculateRewardsPoolsPerToken(
       balances,
-      rewardPool
+      rewardPool,
+      totalBalances,
     );
 
-    const totalBalances = this.calculateTotalEligibleBalances(balances);
-
-    const tokensWithBalance = this.getTokensWithBalance(balances);
+    const tokensWithBalance = this.getTokensWithBalance(balances, totalBalances);
     // Calculate each address's share of the rewards
     const rewards = new Map<string, Map<string, bigint>>();
     for (const token of tokensWithBalance) {


### PR DESCRIPTION
## Summary
- Extract tick retry constants from magic numbers in liquidity.ts (Fixes #113)
- Rename UPPER_CASE local variables to camelCase in main() (Fixes #107)
- Avoid redundant calculateTotalEligibleBalances calls in calculateRewards (Fixes #121)

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)