### PR TITLE
Easy fixes 7: dedup scraper env, single-pass summarize

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -103,10 +103,16 @@ export function summarizeTokenBalances(balances: EligibleBalances, cytokens: CyT
     const tokenBalances = balances.get(token.address);
     if (!tokenBalances) continue;
 
-    const totalAverage = Array.from(tokenBalances.values()).reduce((sum, bal) => sum + bal.average, 0n);
-    const totalPenalties = Array.from(tokenBalances.values()).reduce((sum, bal) => sum + bal.penalty, 0n);
-    const totalBounties = Array.from(tokenBalances.values()).reduce((sum, bal) => sum + bal.bounty, 0n);
-    const totalFinal = Array.from(tokenBalances.values()).reduce((sum, bal) => sum + bal.final, 0n);
+    let totalAverage = 0n;
+    let totalPenalties = 0n;
+    let totalBounties = 0n;
+    let totalFinal = 0n;
+    for (const bal of tokenBalances.values()) {
+      totalAverage += bal.average;
+      totalPenalties += bal.penalty;
+      totalBounties += bal.bounty;
+      totalFinal += bal.final;
+    }
 
     summaries.push({
       name: token.name,

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -6,18 +6,15 @@
 import { request, gql } from "graphql-request";
 import { writeFile } from "fs/promises";
 import { LiquidityChange, LiquidityChangeType, Transfer } from "./types";
-import { DATA_DIR, LIQUIDITY_FILE, POOLS_FILE, TRANSFER_CHUNK_SIZE, TRANSFER_FILE_COUNT, TRANSFERS_FILE_BASE, EPOCHS, CURRENT_EPOCH, validateAddress } from "./constants";
+import { DATA_DIR, LIQUIDITY_FILE, POOLS_FILE, TRANSFER_CHUNK_SIZE, TRANSFER_FILE_COUNT, TRANSFERS_FILE_BASE, SUBGRAPH_URL, validateAddress } from "./constants";
+import { parseEnv } from "./config";
 import assert from "assert";
 
-/** Goldsky-hosted Cyclo subgraph endpoint for the current epoch */
-const SUBGRAPH_URL =
-  "https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-09-ae4f/gn";
 const BATCH_SIZE = 1000;
 
-const epoch = EPOCHS[CURRENT_EPOCH - 1];
-assert(epoch, `No epoch found for CURRENT_EPOCH ${CURRENT_EPOCH}`);
+const { endSnapshot } = parseEnv();
 // +1 to make sure every transfer at the end snapshot block is gathered
-const UNTIL_SNAPSHOT = epoch.endBlock + 1;
+const UNTIL_SNAPSHOT = endSnapshot + 1;
 
 /** Raw transfer event shape from the Goldsky subgraph GraphQL response */
 export interface SubgraphTransfer {

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -6,10 +6,13 @@
 import { request, gql } from "graphql-request";
 import { writeFile } from "fs/promises";
 import { LiquidityChange, LiquidityChangeType, Transfer } from "./types";
-import { DATA_DIR, LIQUIDITY_FILE, POOLS_FILE, TRANSFER_CHUNK_SIZE, TRANSFER_FILE_COUNT, TRANSFERS_FILE_BASE, SUBGRAPH_URL, validateAddress } from "./constants";
+import { DATA_DIR, LIQUIDITY_FILE, POOLS_FILE, TRANSFER_CHUNK_SIZE, TRANSFER_FILE_COUNT, TRANSFERS_FILE_BASE, validateAddress } from "./constants";
 import { parseEnv } from "./config";
 import assert from "assert";
 
+/** Goldsky-hosted Cyclo subgraph endpoint for the current epoch */
+const SUBGRAPH_URL =
+  "https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-09-ae4f/gn";
 const BATCH_SIZE = 1000;
 
 const { endSnapshot } = parseEnv();


### PR DESCRIPTION
## Summary
- Use parseEnv() in scraper instead of duplicating epoch lookup (Fixes #103)
- Single-pass iteration in summarizeTokenBalances (Fixes #114)

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)