### PR TITLE
Fix off-by-one in scraper UNTIL_SNAPSHOT

### DIFF
--- a/src/scraper.test.ts
+++ b/src/scraper.test.ts
@@ -6,7 +6,9 @@ import {
   SubgraphTransfer,
   SubgraphLiquidityChangeV2,
   SubgraphLiquidityChangeV3,
+  UNTIL_SNAPSHOT,
 } from "./scraper";
+import { EPOCHS, CURRENT_EPOCH } from "./constants";
 
 /** Minimal valid subgraph transfer for test construction */
 const VALID_SUBGRAPH_TRANSFER: SubgraphTransfer = {
@@ -329,6 +331,13 @@ describe("parseIntStrict", () => {
     expect(parseIntStrict(100 as unknown as string, "test")).toBe(100);
     expect(parseIntStrict(0 as unknown as string, "test")).toBe(0);
     expect(parseIntStrict(-42 as unknown as string, "test")).toBe(-42);
+  });
+});
+
+describe("UNTIL_SNAPSHOT", () => {
+  it("equals endBlock (blockNumber_lte is inclusive, no +1 needed)", () => {
+    const epoch = EPOCHS[CURRENT_EPOCH - 1];
+    expect(UNTIL_SNAPSHOT).toBe(epoch.endBlock);
   });
 });
 

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -16,8 +16,8 @@ const BATCH_SIZE = 1000;
 
 const epoch = EPOCHS[CURRENT_EPOCH - 1];
 assert(epoch, `No epoch found for CURRENT_EPOCH ${CURRENT_EPOCH}`);
-// +1 to make sure every transfer at the end snapshot block is gathered
-const UNTIL_SNAPSHOT = epoch.endBlock + 1;
+// blockNumber_lte is inclusive, so no +1 needed
+export const UNTIL_SNAPSHOT = epoch.endBlock;
 
 /** Raw transfer event shape from the Goldsky subgraph GraphQL response */
 export interface SubgraphTransfer {


### PR DESCRIPTION
## Summary
- Fix `UNTIL_SNAPSHOT` off-by-one: `blockNumber_lte` is inclusive so `+1` fetched one extra block past epoch end (Fixes #124)

## Test plan
- [x] Added test asserting UNTIL_SNAPSHOT == endBlock
- [x] Unit tests pass
- [ ] CI git-clean will rescrape (may produce different data if events exist at endBlock+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)