### PR TITLE
Move RPC_URL assertion out of config module scope

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { generateSnapshotBlocks, scaleTo18, parseEnv, isSameAddress, REWARDS_SOURCES, FACTORIES, CYTOKENS } from './config';
 import { VALID_ADDRESS_REGEX, EPOCHS, CURRENT_EPOCH, SNAPSHOT_COUNT } from './constants';
 
@@ -97,24 +97,6 @@ describe('generateSnapshotBlocks', () => {
     }
     // Should complete in well under 1 second (shuffle is O(n))
     expect(elapsed).toBeLessThan(1000);
-  });
-});
-
-describe("RPC_URL", () => {
-  it("should export RPC_URL from environment", async () => {
-    const { RPC_URL } = await import('./config');
-    expect(RPC_URL).toBe(process.env.RPC_URL);
-  });
-
-  it("should error if RPC_URL is not set", async () => {
-    const original = process.env.RPC_URL;
-    delete process.env.RPC_URL;
-    try {
-      vi.resetModules();
-      await expect(import('./config')).rejects.toThrow("RPC_URL environment variable must be set");
-    } finally {
-      process.env.RPC_URL = original;
-    }
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,10 +50,6 @@ export const CYTOKENS: CyToken[] = [
   },
 ];
 
-assert(process.env.RPC_URL, "RPC_URL environment variable must be set");
-/** Flare RPC endpoint URL for on-chain queries */
-export const RPC_URL = process.env.RPC_URL;
-
 /**
  * Case-insensitive comparison of two Ethereum addresses
  * @param a - First address

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import { createPublicClient, http } from "viem";
 import { flare } from "viem/chains";
 import { Processor } from "./processor";
 import { config } from "dotenv";
-import { CYTOKENS, generateSnapshotBlocks, parseEnv, RPC_URL } from "./config";
+import assert from "assert";
+import { CYTOKENS, generateSnapshotBlocks, parseEnv } from "./config";
 import { aggregateRewardsPerAddress, filterZeroRewards, formatBalancesCsv, formatRewardsCsv, parseBlocklist, parseJsonl, parsePools, readOptionalFile, sortAddressesByReward, summarizeTokenBalances, normalizeTransfer, normalizeLiquidityChange, verifyRewardPoolTolerance } from "./pipeline";
 import { BLOCKLIST_FILE, DATA_DIR, LIQUIDITY_FILE, OUTPUT_DIR, POOLS_FILE, REWARD_POOL, TRANSFER_FILE_COUNT, TRANSFERS_FILE_BASE } from "./constants";
 import { LiquidityChange, Transfer } from "./types";
@@ -24,6 +25,9 @@ config();
  * processes all events through the Processor, and writes output CSVs.
  */
 async function main() {
+  assert(process.env.RPC_URL, "RPC_URL environment variable must be set");
+  const RPC_URL = process.env.RPC_URL;
+
   const { seed: SEED, startSnapshot: START_SNAPSHOT, endSnapshot: END_SNAPSHOT } = parseEnv();
 
   // generate snapshot blocks


### PR DESCRIPTION
## Summary
- Move RPC_URL assertion from config.ts module level to index.ts main(), so importing config for pure utilities doesn't require RPC_URL (Fixes #102)

## Test plan
- [x] All existing tests pass
- [x] Removed config RPC_URL tests (no longer relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)