### PR TITLE
Optimize processLpRange: iterate positions not accounts

### DIFF
--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -1984,6 +1984,85 @@ describe("Processor", () => {
         const updatedBalance = balanceMap.get(ownerAddress);
         expect(updatedBalance.netBalanceAtSnapshots).toEqual([400n, 500n, 400n]); // Deduct 100n for snapshots 0 and 2
       });
+
+      it('should accumulate deductions from multiple out-of-range positions for same owner', async () => {
+        const poolTicks = {
+          '0x1111111111111111111111111111111111111111': 100,
+        };
+        (getPoolsTick as Mock).mockResolvedValue(poolTicks);
+
+        const tokenAddress = '0xtoken123';
+        const ownerAddress = '0xowner123';
+        const poolAddress = '0x1111111111111111111111111111111111111111';
+
+        const accountBalancesPerToken = (processor as any).accountBalancesPerToken;
+        const balanceMap = new Map();
+        balanceMap.set(ownerAddress, {
+          transfersInFromApproved: 1000n,
+          transfersOut: 0n,
+          netBalanceAtSnapshots: [500n, 500n, 500n],
+        });
+        accountBalancesPerToken.set(tokenAddress, balanceMap);
+
+        const lpTrackList = (processor as any).lp3TrackList;
+        // Two positions, both out of range
+        for (const snapshot of snapshots) {
+          lpTrackList[snapshot].set(`${tokenAddress}-${ownerAddress}-${poolAddress}-1`, {
+            value: 100n,
+            pool: poolAddress,
+            lowerTick: 150,
+            upperTick: 250,
+          });
+          lpTrackList[snapshot].set(`${tokenAddress}-${ownerAddress}-${poolAddress}-2`, {
+            value: 150n,
+            pool: poolAddress,
+            lowerTick: 200,
+            upperTick: 300,
+          });
+        }
+
+        await processor.processLpRange();
+
+        const updatedBalance = balanceMap.get(ownerAddress);
+        // Both positions deducted: 500 - 100 - 150 = 250
+        expect(updatedBalance.netBalanceAtSnapshots).toEqual([250n, 250n, 250n]);
+      });
+
+      it('should clamp balance to zero when deductions exceed balance', async () => {
+        const poolTicks = {
+          '0x1111111111111111111111111111111111111111': 100,
+        };
+        (getPoolsTick as Mock).mockResolvedValue(poolTicks);
+
+        const tokenAddress = '0xtoken123';
+        const ownerAddress = '0xowner123';
+        const poolAddress = '0x1111111111111111111111111111111111111111';
+
+        const accountBalancesPerToken = (processor as any).accountBalancesPerToken;
+        const balanceMap = new Map();
+        balanceMap.set(ownerAddress, {
+          transfersInFromApproved: 100n,
+          transfersOut: 0n,
+          netBalanceAtSnapshots: [50n, 50n, 50n],
+        });
+        accountBalancesPerToken.set(tokenAddress, balanceMap);
+
+        const lpTrackList = (processor as any).lp3TrackList;
+        for (const snapshot of snapshots) {
+          lpTrackList[snapshot].set(`${tokenAddress}-${ownerAddress}-${poolAddress}-1`, {
+            value: 200n, // Exceeds balance of 50
+            pool: poolAddress,
+            lowerTick: 150,
+            upperTick: 250,
+          });
+        }
+
+        await processor.processLpRange();
+
+        const updatedBalance = balanceMap.get(ownerAddress);
+        // Clamped to 0, not negative
+        expect(updatedBalance.netBalanceAtSnapshots).toEqual([0n, 0n, 0n]);
+      });
     });
   });
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -612,23 +612,33 @@ export class Processor {
         block,
       );
 
-      // iter tokens
-      for (const [token, account] of this.accountBalancesPerToken) {
-        // iter accounts
-        for (const [owner, balance] of account) {
-          // iter tracked lp v3 position
-          for (const [key, lp] of lpTrackList) {
-            const tick = poolsTicks[lp.pool];
-            if (tick === undefined) continue;
+      // Collect deductions per token+owner from out-of-range positions
+      const deductions = new Map<string, Map<string, bigint>>();
+      for (const [key, lp] of lpTrackList) {
+        if (lp.value <= 0n) continue;
+        const tick = poolsTicks[lp.pool];
+        if (tick === undefined) continue;
+        if (lp.lowerTick <= tick && tick < lp.upperTick) continue; // skip if in range (upper bound exclusive per Uniswap V3)
 
-            const idStart = `${token}-${owner}-${lp.pool}-`;
-            if (!key.startsWith(idStart)) continue;
-            if (lp.value <= 0n) continue;
-            if (lp.lowerTick <= tick && tick < lp.upperTick) continue; // skip if in range (upper bound exclusive per Uniswap V3)
+        // Extract token and owner from position key: token-owner-pool-tokenId
+        const firstDash = key.indexOf("-");
+        const secondDash = key.indexOf("-", firstDash + 1);
+        const token = key.substring(0, firstDash);
+        const owner = key.substring(firstDash + 1, secondDash);
 
-            // deduct out of range lp position for snapshot
-            balance.netBalanceAtSnapshots[i] -= lp.value;
-          }; 
+        if (!deductions.has(token)) deductions.set(token, new Map());
+        const ownerDeductions = deductions.get(token)!;
+        ownerDeductions.set(owner, (ownerDeductions.get(owner) ?? 0n) + lp.value);
+      }
+
+      // Apply deductions to snapshot balances
+      for (const [token, ownerDeductions] of deductions) {
+        const accountBalances = this.accountBalancesPerToken.get(token);
+        if (!accountBalances) continue;
+        for (const [owner, deduction] of ownerDeductions) {
+          const balance = accountBalances.get(owner);
+          if (!balance) continue;
+          balance.netBalanceAtSnapshots[i] -= deduction;
           if (balance.netBalanceAtSnapshots[i] < 0n) {
             balance.netBalanceAtSnapshots[i] = 0n;
           }


### PR DESCRIPTION
## Summary
- Refactor processLpRange from O(snapshots * tokens * accounts * positions) to O(snapshots * positions) by iterating LP positions directly and looking up account balances, instead of scanning all positions for each account via string prefix match (Fixes #120)

## Test plan
- [x] All existing unit tests pass (including V3 range deduction tests)
- [ ] CI git-clean verifies output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)