### PR TITLE
Pass pre-computed balances to calculateRewards

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ async function main() {
 
   // Write balances with per-token data
   console.log("Writing balances...");
-  const rewardsPerToken = await processor.calculateRewards(REWARD_POOL);
+  const rewardsPerToken = await processor.calculateRewards(REWARD_POOL, balances);
   for (const token of CYTOKENS) {
     const tokenRewards = rewardsPerToken.get(token.address);
     if (tokenRewards) {

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -752,7 +752,8 @@ describe("Processor", () => {
       await processor.processLiquidityPositions(liq2);
 
       const rewardPool = ONEn;
-      const result = await processor.calculateRewards(rewardPool);
+      const balances = await processor.getEligibleBalances();
+      const result = await processor.calculateRewards(rewardPool, balances);
 
       const user1Reward = result.get(CYTOKENS[0].address)?.get(NORMAL_USER_1);
       const user2Reward = result.get(CYTOKENS[0].address)?.get(NORMAL_USER_2);
@@ -782,11 +783,10 @@ describe("Processor", () => {
       await buyAndDeposit(processor, NORMAL_USER_2, "88000000000000000000", CYTOKENS[1].address, 50);
 
       const rewardPool = 1_000_000n * ONEn;
-      const result = await processor.calculateRewards(rewardPool);
+      const balances = await processor.getEligibleBalances();
+      const result = await processor.calculateRewards(rewardPool, balances);
       expect(result.get(CYTOKENS[0].address)?.get(NORMAL_USER_1)).not.toBeUndefined();
       expect(result.get(CYTOKENS[1].address)?.get(NORMAL_USER_2)).not.toBeUndefined();
-
-      const balances = await processor.getEligibleBalances();
       expect(balances.get(CYTOKENS[0].address)?.get(NORMAL_USER_1)?.average).toBe(50000000000000000000n);
       expect(balances.get(CYTOKENS[1].address)?.get(NORMAL_USER_1)?.average).toBe(0n);
       expect(balances.get(CYTOKENS[0].address)?.get(NORMAL_USER_2)?.average).toBe(0n);
@@ -809,7 +809,8 @@ describe("Processor", () => {
       await buyAndDeposit(processor, NORMAL_USER_2, "3000000000000000000", CYTOKENS[0].address, 50);
 
       const rewardPool = ONEn;
-      const result = await processor.calculateRewards(rewardPool);
+      const balances = await processor.getEligibleBalances();
+      const result = await processor.calculateRewards(rewardPool, balances);
 
       const user1Reward = result.get(CYTOKENS[0].address)?.get(NORMAL_USER_1);
       const user2Reward = result.get(CYTOKENS[0].address)?.get(NORMAL_USER_2);

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -474,10 +474,10 @@ export class Processor {
    * End-to-end reward calculation: computes eligible balances, splits the pool across tokens,
    * then distributes each token's share proportionally to account balances.
    * @param rewardPool - Total reward pool in wei
+   * @param balances - Pre-computed eligible balances (avoids redundant getEligibleBalances call)
    * @returns Token address → user address → reward amount in wei
    */
-  async calculateRewards(rewardPool: bigint): Promise<RewardsPerToken> {
-    const balances = await this.getEligibleBalances();
+  async calculateRewards(rewardPool: bigint, balances: EligibleBalances): Promise<RewardsPerToken> {
     const totalBalances = this.calculateTotalEligibleBalances(balances);
 
     const totalRewardsPerToken = this.calculateRewardsPoolsPerToken(


### PR DESCRIPTION
## Summary
- Avoid redundant `getEligibleBalances()` call — index.ts computes it for verification, now passes it to `calculateRewards()` instead of recomputing (Fixes #140)

## Test plan
- [x] All existing tests pass (updated to pass balances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)