### PR TITLE
Guard against unknown __typename and duplicate cheaters

### DIFF
--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -617,6 +617,16 @@ describe("Processor", () => {
     });
   });
 
+  describe("Duplicate cheater rejection", () => {
+    it("should throw if the same cheater is reported twice", () => {
+      const reports = [
+        { reporter: NORMAL_USER_1, cheater: NORMAL_USER_2 },
+        { reporter: "0x0000000000000000000000000000000000000099", cheater: NORMAL_USER_2 },
+      ];
+      expect(() => new Processor(SNAPSHOTS, reports, mockClient)).toThrow("cheater");
+    });
+  });
+
   describe("Inverse-fraction reward weighting", () => {
     it("should allocate more rewards to token with less total eligible balance", async () => {
       // Token A: 100 total eligible (one user)

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -91,6 +91,15 @@ export class Processor {
   ) {
     this.client = client;
 
+    // Reject duplicate cheaters — stacking penalties leads to negative balances
+    const cheaters = new Set<string>();
+    for (const report of reports) {
+      if (cheaters.has(report.cheater)) {
+        throw new Error(`Duplicate cheater in blocklist: ${report.cheater}`);
+      }
+      cheaters.add(report.cheater);
+    }
+
     // Initialize token balances maps
     for (const token of CYTOKENS) {
       const balanceMap = new Map<string, AccountBalance>();

--- a/src/scraper.test.ts
+++ b/src/scraper.test.ts
@@ -302,6 +302,14 @@ describe("mapSubgraphLiquidityChange", () => {
     const liq = { ...VALID_V3_LIQUIDITY, tokenId: "abc" };
     expect(() => mapSubgraphLiquidityChange(liq)).toThrow("tokenId");
   });
+
+  it("should throw on unknown __typename", () => {
+    const unknown = {
+      ...VALID_V2_LIQUIDITY,
+      __typename: "LiquidityV99Change" as any,
+    };
+    expect(() => mapSubgraphLiquidityChange(unknown)).toThrow("__typename");
+  });
 });
 
 describe("parseIntStrict", () => {

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -143,6 +143,9 @@ export function mapSubgraphLiquidityChange(t: SubgraphLiquidityChange): Liquidit
       upperTick: parseIntStrict(t.upperTick, "upperTick"),
     };
   }
+  if (t.__typename !== "LiquidityV2Change") {
+    throw new Error(`Unknown liquidity change __typename: "${t.__typename}"`);
+  }
   return { __typename: t.__typename, ...base };
 }
 


### PR DESCRIPTION
## Summary
- Add runtime guard for unknown `__typename` in liquidity change mapping (Fixes #142)
- Reject duplicate cheaters in blocklist to prevent penalty stacking causing negative balances (Fixes #139)

## Test plan
- [x] TDD: failing tests written first, then fixes applied
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)