### PR TITLE
Easy fixes 14: tick index constant, truncation docs, test

### DIFF
--- a/src/liquidity.ts
+++ b/src/liquidity.ts
@@ -8,6 +8,9 @@ import { TICK_RETRY_ATTEMPTS, TICK_RETRY_DELAY_MS } from "./constants";
 /** Multicall3 canonical deployment address (same on all EVM chains) */
 export const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11" as const;
 
+/** Index of the `tick` field in the slot0 return tuple */
+const SLOT0_TICK_INDEX = 1;
+
 /** Uniswap V3 pool slot0 ABI — returns current tick and other pool state */
 const abi = [
     {
@@ -85,7 +88,7 @@ export async function getPoolsTickMulticall(
         const res = results[i];
         const pool = pools[i];
         if (res.status === "success") {
-            ticks[pool] = res.result[1];
+            ticks[pool] = res.result[SLOT0_TICK_INDEX];
         }
     }
 

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -820,6 +820,29 @@ describe("Processor", () => {
     });
   });
 
+  describe("Reward truncation", () => {
+    it("total rewards should be <= pool due to BigInt truncation", async () => {
+      // Use amounts that don't divide evenly to force truncation
+      await buyAndDeposit(processor, NORMAL_USER_1, "3000000000000000000", CYTOKENS[0].address, 50);
+      await buyAndDeposit(processor, NORMAL_USER_2, "7000000000000000000", CYTOKENS[0].address, 50);
+
+      const rewardPool = ONEn;
+      const balances = await processor.getEligibleBalances();
+      const result = await processor.calculateRewards(rewardPool, balances);
+
+      let totalDistributed = 0n;
+      for (const tokenRewards of result.values()) {
+        for (const reward of tokenRewards.values()) {
+          totalDistributed += reward;
+        }
+      }
+
+      expect(totalDistributed).toBeLessThanOrEqual(rewardPool);
+      // Should be very close — within 1 wei per account per token
+      expect(rewardPool - totalDistributed).toBeLessThan(10n);
+    });
+  });
+
   describe("Bought cap recovery", () => {
     it("should recover from negative bought cap with a subsequent buy", async () => {
       const tokenAddress = CYTOKENS[0].address;

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -456,7 +456,8 @@ export class Processor {
       tokenInverseFractions.values()
     ).reduce((acc, inverseFraction) => acc + inverseFraction, 0n);
 
-    // Calculate each token's share of the reward pool
+    // Calculate each token's share of the reward pool.
+    // BigInt truncation means token shares sum to <= rewardPool.
     const totalRewardsPerToken = new Map<string, bigint>();
     for (const token of tokensWithBalance) {
       const tokenInverseFraction = tokenInverseFractions.get(
@@ -495,6 +496,9 @@ export class Processor {
 
       const tokenRewards = new Map<string, bigint>();
       for (const [address, balance] of tokenBalances) {
+        // BigInt division truncates toward zero, so the sum of all rewards
+        // will be slightly less than the pool. This is the correct direction
+        // (under-distribute, never over-distribute).
         const reward =
           (balance.final18 *
             totalRewardsPerToken.get(token.address)!) /


### PR DESCRIPTION
## Summary
- Name magic index `result[1]` for tick extraction from slot0 (Fixes #132)
- Document BigInt truncation in reward calculation and add test asserting total <= pool (Fixes #137)

## Test plan
- [x] All existing tests pass
- [x] New test verifies truncation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)