### PR TITLE
Add missing JSDoc to processor.ts methods

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -181,8 +181,9 @@ export class Processor {
 
   /**
    * Processes a single ERC-20 transfer, updating sender and receiver balances.
-   * Only credits the receiver if the sender is an approved source.
-   * Handles LP deposit/withdraw adjustments via linked liquidity events.
+   * Only credits the receiver's boughtCap if the sender is an approved source.
+   * The sender's boughtCap is always decremented (reversal: selling undoes buying).
+   * LP deposits and withdrawals are detected and skipped — they don't affect boughtCap.
    * @param transfer - Transfer event to process
    */
   async processTransfer(transfer: Transfer) {
@@ -305,6 +306,7 @@ export class Processor {
   /**
    * Computes reward-eligible balances for all accounts across all tokens.
    * Three passes: (1) average snapshot balances, (2) penalties/bounties, (3) final balances scaled to 18 decimals.
+   * Note: `final` can be negative for penalized accounts (penalty > average + bounty).
    * @returns Token address → user address → TokenBalances
    */
   async getEligibleBalances(): Promise<EligibleBalances> {
@@ -420,8 +422,14 @@ export class Processor {
   /**
    * Splits the reward pool across tokens using inverse-fraction weighting.
    * Tokens with smaller total balances receive a larger share of rewards.
+   *
+   * Formula: for each token, inverseFraction = (sumAllBalances * ONE_18) / tokenBalance.
+   * ONE_18 scaling preserves precision in the BigInt division. Each token's pool share
+   * is then (inverseFraction * rewardPool) / sumOfInverseFractions.
+   *
    * @param balances - Eligible balances from getEligibleBalances()
    * @param rewardPool - Total reward pool in wei
+   * @param totalBalances - Pre-computed total eligible balances per token (optional, avoids recomputation)
    * @returns Token address → reward pool share for that token
    */
   calculateRewardsPoolsPerToken(
@@ -537,7 +545,10 @@ export class Processor {
   }
 
   /**
-   * Processes a liquidity change event, updating the owner's balance and snapshot records.
+   * Processes a liquidity change event, updating the owner's lpBalance and snapshot records.
+   * Handles all change types uniformly via depositedBalanceChange sign:
+   * - Deposit: positive depositedBalanceChange increases lpBalance
+   * - Withdraw/Transfer: negative depositedBalanceChange decreases lpBalance
    * For V3 positions, also tracks the position in lp3TrackList for later in-range checks.
    * @param liquidityChangeEvent - Liquidity event to process
    */


### PR DESCRIPTION
## Summary
- Document boughtCap reversal in processTransfer (Fixes #85)
- Note that final can be negative in getEligibleBalances (Fixes #84)
- Document Deposit/Withdraw/Transfer handling in processLiquidityPositions (Fixes #86)
- Document inverse-fraction formula and ONE_18 scaling in calculateRewardsPoolsPerToken (Fixes #87)

## Test plan
- [x] All tests pass (JSDoc-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)