### PR TITLE
Audit triage: Pass 0 + Pass 1 fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,15 @@ Vitest runs in watch mode. For a single run, use
   `sortAddressesByReward`, `filterZeroRewards`.
 - **`src/liquidity.ts`** — Queries Uniswap V3 pool tick data via multicall at
   specific blocks. Uses 3 attempts with fixed 10-second delay between retries.
+- **`src/diff.ts`** — CSV reading and diff calculation for epoch reconciliation.
+  Provides `readCsv`, `calculateDiff`, and related types used by
+  `diffCalculator.ts`.
 - **`src/diffCalculator.ts`** — Standalone script (not part of `npm run start`).
   Compares new rewards CSV against a previous rewards CSV (e.g.,
   `output/rewards-*-old.csv`) to produce diff CSVs for underpaid, covered, and
   uncovered accounts. Currently configured for Dec 2025 epoch reconciliation.
+- **`src/shuffle.ts`** — Fisher-Yates shuffle used by `generateSnapshotBlocks()`
+  for deterministic snapshot block selection.
 - **`src/config.ts`** — Approved DEX routers (`REWARDS_SOURCES`), factory
   contracts (`FACTORIES`), cyToken definitions (`CYTOKENS`), RPC URL, and
   `generateSnapshotBlocks()` which uses seedrandom for deterministic block
@@ -72,6 +77,8 @@ Vitest runs in watch mode. For a single run, use
 - **`scripts/fetch-dec-2025-distributed.sh`** — Decodes on-chain distribution
   transactions to produce `output/dec-2025-distributed.csv`. Run in CI before
   the main pipeline.
+- **`scripts/find-epoch-blocks.ts`** — Looks up block numbers for epoch
+  boundaries by binary-searching Flare C-chain timestamps.
 
 ## Environment Variables
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,12 +75,14 @@ Vitest runs in watch mode. For a single run, use
 
 ## Environment Variables
 
-Set in `.env` (and mirrored in `.github/workflows/git-clean.yaml`):
+Set in `.env` (loaded via dotenv at runtime):
 
-- `SEED` — Seed phrase for deterministic snapshot block generation
-- `START_SNAPSHOT` — Starting block number
-- `END_SNAPSHOT` — Ending block number
-- `RPC_URL` — Flare RPC endpoint
+- `RPC_URL` — Flare RPC endpoint (also set as a secret in
+  `.github/workflows/git-clean.yaml`)
+
+Epoch configuration (seed, startBlock, endBlock) is defined in the `EPOCHS`
+array in `src/constants.ts`. See the epoch transition steps in `readme.md` for
+how to configure a new epoch.
 
 ## Key Concepts
 

--- a/readme.md
+++ b/readme.md
@@ -32,29 +32,21 @@ git add .
 git commit -am'move dispersed csvs'
 ```
 
-## 3. Pick a seed phrase and block range
+## 3. Configure the new epoch
 
-Pick the seed phrase and block range for the current epoch. The seed follows the
-pattern `cyclo-rewards-for-{month}-{year}`. Block range should cover the epoch
-period from the schedule below. Set these in `.env` and `.github/workflows/git-clean.yaml`.
+In `src/constants.ts`:
 
-E.g. `.env`
+1. Add the new epoch's `seed`, `startBlock`, and `endBlock` to the `EPOCHS`
+   array.
+   - Use `scripts/find-epoch-blocks.ts` to find the correct block numbers.
+   - Generate a random seed (e.g. `openssl rand -hex 16`). Do NOT use
+     predictable patterns.
+2. Update `CURRENT_EPOCH` to the new epoch number.
+3. Add a new reward pool constant (e.g. `APR26_REWARD_POOL`) and update
+   `REWARD_POOL` to point to it.
 
-```
-SEED="this-is-my-seed"
-START_SNAPSHOT=41280134
-END_SNAPSHOT=41290134
-```
-
-`git-clean.yaml`
-
-```
-      - run: nix develop -c npm run start
-        env:
-          SEED: "this-is-my-seed"
-          START_SNAPSHOT: 41280134
-          END_SNAPSHOT: 41290134
-```
+Ensure `RPC_URL` is set in `.env` locally and as a secret in
+`.github/workflows/git-clean.yaml`.
 
 ## 4. Run the script local
 
@@ -64,13 +56,14 @@ The script will fetch all transfers and build csvs of the balances and rewards.
 nix develop -c npm run start
 ```
 
-You should see updates to `data/transfers*.dat` and a new `output/balances-X-Y.csv`
-and `output/rewards-X-Y.csv` where `X` and `Y` match the block numbers in the
-environment.
+You should see updates to `data/transfers*.dat` and a new
+`output/balances-X-Y.csv` and `output/rewards-X-Y.csv` where `X` and `Y` match
+the block numbers in the environment.
 
 ## 5. Commit and setup a PR
 
-Just commit all the changes from setting up the environment and running the script.
+Just commit all the changes from setting up the environment and running the
+script.
 
 Create a PR on the repo, and check that the `git-clean` workflow passes on CI.
 
@@ -79,27 +72,28 @@ announce to the community.
 
 ## rFLR Emissions Epochs Schedule
 
-All dates are epoch end dates at 12:00 UTC (source: [Flare rFLR guide](https://flare.network/news/a-guide-to-rflr-rewards)):
+All dates are epoch end dates at 12:00 UTC (source:
+[Flare rFLR guide](https://flare.network/news/a-guide-to-rflr-rewards)):
 
-| # | Epoch End | Seed Pattern |
-|---|-----------|-------------|
-| 1 | 06 Jul 2024 12:00 | |
-| 2 | 05 Aug 2024 12:00 | |
-| 3 | 04 Sep 2024 12:00 | |
-| 4 | 04 Oct 2024 12:00 | |
-| 5 | 03 Nov 2024 12:00 | |
-| 6 | 03 Dec 2024 12:00 | |
-| 7 | 02 Jan 2025 12:00 | |
-| 8 | 01 Feb 2025 12:00 | |
-| 9 | 03 Mar 2025 12:00 | |
-| 10 | 02 Apr 2025 12:00 | |
-| 11 | 02 May 2025 12:00 | |
-| 12 | 01 Jun 2025 12:00 | |
-| 13 | 01 Jul 2025 12:00 | |
-| 14 | 31 Jul 2025 12:00 | |
-| 15 | 30 Aug 2025 12:00 | |
-| 16 | 29 Sep 2025 12:00 | |
-| 17 | 29 Oct 2025 12:00 | |
+| #  | Epoch End         | Seed Pattern                 |
+| -- | ----------------- | ---------------------------- |
+| 1  | 06 Jul 2024 12:00 |                              |
+| 2  | 05 Aug 2024 12:00 |                              |
+| 3  | 04 Sep 2024 12:00 |                              |
+| 4  | 04 Oct 2024 12:00 |                              |
+| 5  | 03 Nov 2024 12:00 |                              |
+| 6  | 03 Dec 2024 12:00 |                              |
+| 7  | 02 Jan 2025 12:00 |                              |
+| 8  | 01 Feb 2025 12:00 |                              |
+| 9  | 03 Mar 2025 12:00 |                              |
+| 10 | 02 Apr 2025 12:00 |                              |
+| 11 | 02 May 2025 12:00 |                              |
+| 12 | 01 Jun 2025 12:00 |                              |
+| 13 | 01 Jul 2025 12:00 |                              |
+| 14 | 31 Jul 2025 12:00 |                              |
+| 15 | 30 Aug 2025 12:00 |                              |
+| 16 | 29 Sep 2025 12:00 |                              |
+| 17 | 29 Oct 2025 12:00 |                              |
 | 18 | 28 Nov 2025 12:00 | `cyclo-rewards-for-nov-2025` |
 | 19 | 28 Dec 2025 12:00 | `cyclo-rewards-for-dec-2025` |
 | 20 | 27 Jan 2026 12:00 | `cyclo-rewards-for-jan-2026` |

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -135,7 +135,9 @@ describe("generateSnapshotBlocks", () => {
   });
 
   it("should throw on inverted range (start > end)", () => {
-    expect(() => generateSnapshotBlocks("test-seed", 9000, 5000)).toThrow();
+    expect(() => generateSnapshotBlocks("test-seed", 9000, 5000)).toThrow(
+      "start (9000) must be <= end (5000)",
+    );
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,7 @@ export function generateSnapshotBlocks(
     Number.isInteger(end) && end >= 0,
     `end must be a non-negative integer, got ${end}`,
   );
+  assert(start <= end, `start (${start}) must be <= end (${end})`);
   const rng = seedrandom(seed);
   const range = end - start + 1;
 

--- a/src/distribution.test.ts
+++ b/src/distribution.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from "vitest";
 import { createPublicClient, http, decodeFunctionData, parseAbi } from "viem";
 import { flare } from "viem/chains";
 import { readFileSync } from "fs";
-import { EPOCHS, CURRENT_EPOCH, REWARDS_CSV_COLUMN_HEADER_ADDRESS, REWARDS_CSV_COLUMN_HEADER_REWARD } from "./constants";
+import {
+  EPOCHS,
+  CURRENT_EPOCH,
+  REWARDS_CSV_COLUMN_HEADER_ADDRESS,
+  REWARDS_CSV_COLUMN_HEADER_REWARD,
+} from "./constants";
 
 const DISTRIBUTOR = "0x5de53560d7043b6c3ECDf74E3A8EB9f59785C4bb";
 const CYCLO_PROJECT_ID = 6n;
@@ -23,7 +28,9 @@ function readRewardsCsv(): Array<{ address: string; amount: bigint }> {
   const path = `./output/rewards-${epoch.startBlock}-${epoch.endBlock}.csv`;
   const data = readFileSync(path, "utf8");
   const lines = data.split("\n").filter(Boolean);
-  expect(lines[0]).toBe(`${REWARDS_CSV_COLUMN_HEADER_ADDRESS},${REWARDS_CSV_COLUMN_HEADER_REWARD}`);
+  expect(lines[0]).toBe(
+    `${REWARDS_CSV_COLUMN_HEADER_ADDRESS},${REWARDS_CSV_COLUMN_HEADER_REWARD}`,
+  );
   return lines.slice(1).map((line) => {
     const [address, amount] = line.split(",");
     return { address: address.toLowerCase(), amount: BigInt(amount) };
@@ -31,40 +38,49 @@ function readRewardsCsv(): Array<{ address: string; amount: bigint }> {
 }
 
 describe("on-chain distribution matches CSV", () => {
-  it("all distributed amounts match the rewards CSV exactly", async () => {
+  it("all distributed amounts match the rewards CSV exactly", async (ctx) => {
     const csvEntries = readRewardsCsv();
 
     // Get recent txs from distributor via explorer API
     const response = await fetch(
-      `${EXPLORER_API}?module=account&action=txlist&address=${DISTRIBUTOR}&sort=desc&page=1&offset=20`
+      `${EXPLORER_API}?module=account&action=txlist&address=${DISTRIBUTOR}&sort=desc&page=1&offset=20`,
     );
     const data = await response.json();
     const txHashes: string[] = data.result
-      .filter((tx: any) => tx.to?.toLowerCase() === "0x26d460c3cf931fb2014fa436a49e3af08619810e")
+      .filter(
+        (tx: any) =>
+          tx.to?.toLowerCase() === "0x26d460c3cf931fb2014fa436a49e3af08619810e",
+      )
       .map((tx: any) => tx.hash);
 
     const onchainEntries: Array<{ address: string; amount: bigint }> = [];
 
     for (const hash of txHashes) {
       const tx = await client.getTransaction({ hash: hash as `0x${string}` });
+      let decoded;
       try {
-        const decoded = decodeFunctionData({ abi: distributeAbi, data: tx.input });
-        if (decoded.args[0] !== CYCLO_PROJECT_ID || decoded.args[1] !== RNAT_MONTH) continue;
-        for (let i = 0; i < decoded.args[2].length; i++) {
-          onchainEntries.push({
-            address: decoded.args[2][i].toLowerCase(),
-            amount: decoded.args[3][i],
-          });
-        }
-      } catch {
-        // Not a distributeRewards tx
+        decoded = decodeFunctionData({ abi: distributeAbi, data: tx.input });
+      } catch (e: any) {
+        // Only swallow function selector mismatches — other decode errors should propagate
+        if (e?.name === "AbiFunctionSignatureNotFoundError") continue;
+        throw e;
+      }
+      if (
+        decoded.args[0] !== CYCLO_PROJECT_ID ||
+        decoded.args[1] !== RNAT_MONTH
+      )
+        continue;
+      for (let i = 0; i < decoded.args[2].length; i++) {
+        onchainEntries.push({
+          address: decoded.args[2][i].toLowerCase(),
+          amount: decoded.args[3][i],
+        });
       }
     }
 
-    // Skip if not yet distributed
+    // Skip (not pass) if the current epoch hasn't been distributed yet
     if (onchainEntries.length === 0) {
-      console.log("No distribution found for current epoch — skipping");
-      return;
+      ctx.skip();
     }
 
     expect(onchainEntries.length).toBe(csvEntries.length);

--- a/src/distribution.test.ts
+++ b/src/distribution.test.ts
@@ -40,18 +40,30 @@ function readRewardsCsv(): Array<{ address: string; amount: bigint }> {
 describe("on-chain distribution matches CSV", () => {
   it("all distributed amounts match the rewards CSV exactly", async (ctx) => {
     const csvEntries = readRewardsCsv();
+    const epoch = EPOCHS[CURRENT_EPOCH - 1];
 
-    // Get recent txs from distributor via explorer API
-    const response = await fetch(
-      `${EXPLORER_API}?module=account&action=txlist&address=${DISTRIBUTOR}&sort=desc&page=1&offset=20`,
-    );
-    const data = await response.json();
-    const txHashes: string[] = data.result
-      .filter(
-        (tx: any) =>
-          tx.to?.toLowerCase() === "0x26d460c3cf931fb2014fa436a49e3af08619810e",
-      )
-      .map((tx: any) => tx.hash);
+    // Paginate through distributor txs (desc order) until we pass this epoch's endBlock.
+    // Distribution always happens after epoch end, so once we see txs from before endBlock
+    // we've scanned past any relevant distribution calls.
+    const PAGE_SIZE = 100;
+    const MAX_PAGES = 50;
+    const RNAT_ADDRESS = "0x26d460c3cf931fb2014fa436a49e3af08619810e";
+    const txHashes: string[] = [];
+    for (let page = 1; page <= MAX_PAGES; page++) {
+      const response = await fetch(
+        `${EXPLORER_API}?module=account&action=txlist&address=${DISTRIBUTOR}&sort=desc&page=${page}&offset=${PAGE_SIZE}`,
+      );
+      const data = await response.json();
+      const results: any[] = data.result ?? [];
+      if (results.length === 0) break;
+      for (const tx of results) {
+        if (tx.to?.toLowerCase() === RNAT_ADDRESS) txHashes.push(tx.hash);
+      }
+      // Stop when the oldest tx on this page predates this epoch's endBlock
+      const oldestBlock = Number(results[results.length - 1].blockNumber);
+      if (epoch.endBlock !== undefined && oldestBlock < epoch.endBlock) break;
+      if (results.length < PAGE_SIZE) break;
+    }
 
     const onchainEntries: Array<{ address: string; amount: bigint }> = [];
 

--- a/src/localDataIntegrity.test.ts
+++ b/src/localDataIntegrity.test.ts
@@ -20,6 +20,12 @@ interface LiquidityEvent {
 const events: LiquidityEvent[] = liquidityLines.map((line) => JSON.parse(line));
 
 describe("liquidity.dat integrity", () => {
+  it("contains a meaningful number of events", () => {
+    // Guard against truncated/empty data file — the other integrity tests
+    // vacuously pass on empty input.
+    expect(events.length).toBeGreaterThan(0);
+  });
+
   it("events are sorted by blockNumber", () => {
     for (let i = 1; i < events.length; i++) {
       expect(events[i].blockNumber).toBeGreaterThanOrEqual(

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1195,7 +1195,11 @@ describe("verifyRewardPoolTolerance", () => {
     expect(() => verifyRewardPoolTolerance(tooHigh, pool)).toThrow();
   });
 
-  it("should not throw at exactly the 0.1% boundary", () => {
+  it("should throw on any over-distribution even 1 wei", () => {
+    expect(() => verifyRewardPoolTolerance(pool + 1n, pool)).toThrow();
+  });
+
+  it("should not throw at exactly the 0.1% under-distribution boundary", () => {
     const atBoundary = pool - pool / 1000n;
     expect(() => verifyRewardPoolTolerance(atBoundary, pool)).not.toThrow();
   });

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1216,6 +1216,12 @@ describe("parsePools", () => {
     expect(result[0]).toBe("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   });
 
+  it("should lowercase checksummed addresses", () => {
+    const data = JSON.stringify(["0xAaBbCcDdEeFf00112233445566778899AaBbCcDd"]);
+    const result = parsePools(data);
+    expect(result[0]).toBe("0xaabbccddeeff00112233445566778899aabbccdd");
+  });
+
   it("should reject non-array JSON", () => {
     expect(() => parsePools('{"a": 1}')).toThrow();
   });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -308,10 +308,14 @@ export function verifyRewardPoolTolerance(
   totalRewards: bigint,
   rewardPool: bigint,
 ): void {
-  const diff = totalRewards - rewardPool;
-  const absDiff = diff < 0n ? -diff : diff;
-  if (absDiff > rewardPool / 1000n) {
-    throw new Error(`Reward pool difference too large: ${diff}`);
+  if (totalRewards > rewardPool) {
+    throw new Error(
+      `Over-distribution: totalRewards ${totalRewards} > rewardPool ${rewardPool} (diff: ${totalRewards - rewardPool})`,
+    );
+  }
+  const underDistribution = rewardPool - totalRewards;
+  if (underDistribution > rewardPool / 1000n) {
+    throw new Error(`Under-distribution too large: ${underDistribution}`);
   }
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -362,5 +362,5 @@ export function parsePools(data: string): `0x${string}`[] {
     }
     validateAddress(parsed[i], `pools entry ${i}`);
   }
-  return parsed;
+  return parsed.map((p: string) => p.toLowerCase() as `0x${string}`);
 }

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -655,6 +655,62 @@ describe("Processor", () => {
     });
   });
 
+  describe("Final balance clamp", () => {
+    it("final and final18 are never negative for penalized accounts", async () => {
+      const reports = [{ reporter: NORMAL_USER_1, cheater: NORMAL_USER_2 }];
+      const processor = new Processor(SNAPSHOTS, reports, mockClient);
+      processor.isApprovedSource = async (source: string) =>
+        source === APPROVED_SOURCE;
+
+      // Give cheater a balance
+      const buy: Transfer = {
+        from: APPROVED_SOURCE,
+        to: NORMAL_USER_2,
+        value: ONE,
+        blockNumber: 40,
+        timestamp: 900,
+        tokenAddress: CYTOKENS[0].address,
+        transactionHash: "0x" + "a".repeat(64),
+      };
+      const deposit: Transfer = {
+        from: NORMAL_USER_2,
+        to: "0xpool",
+        value: ONE,
+        blockNumber: 50,
+        timestamp: 1000,
+        tokenAddress: CYTOKENS[0].address,
+        transactionHash: "0xtxhash1",
+      };
+      const lp: LiquidityChange = {
+        tokenAddress: CYTOKENS[0].address,
+        lpAddress: "0xLpAddress",
+        owner: NORMAL_USER_2,
+        changeType: LiquidityChangeType.Deposit,
+        liquidityChange: "1234",
+        depositedBalanceChange: ONE,
+        blockNumber: 50,
+        timestamp: 1000,
+        __typename: "LiquidityV2Change",
+        transactionHash: "0xtxhash1",
+      };
+
+      await processor.organizeLiquidityPositions(lp);
+      await processor.processTransfer(buy);
+      await processor.processTransfer(deposit);
+      await processor.processLiquidityPositions(lp);
+
+      const balances = await processor.getEligibleBalances();
+
+      // Check all accounts across all tokens
+      for (const [, tokenBalances] of balances) {
+        for (const [, balance] of tokenBalances) {
+          expect(balance.final).toBeGreaterThanOrEqual(0n);
+          expect(balance.final18).toBeGreaterThanOrEqual(0n);
+        }
+      }
+    });
+  });
+
   describe("Duplicate cheater rejection", () => {
     it("should throw if the same cheater is reported twice", () => {
       const reports = [

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -2074,6 +2074,56 @@ describe("Processor", () => {
     });
   });
 
+  describe("V3 tick range consistency", () => {
+    it("should throw if same position has mismatched tick range", async () => {
+      const tokenAddress = CYTOKENS[0].address;
+      const txHash1 = nextTxHash();
+      const txHash2 = nextTxHash();
+
+      const v3Event1: LiquidityChange = {
+        tokenAddress,
+        lpAddress: LP_ADDRESS,
+        owner: NORMAL_USER_1,
+        changeType: LiquidityChangeType.Deposit,
+        liquidityChange: ARBITRARY_LIQUIDITY,
+        depositedBalanceChange: ONE,
+        blockNumber: 50,
+        timestamp: 1000,
+        __typename: "LiquidityV3Change",
+        transactionHash: txHash1,
+        tokenId: "42",
+        poolAddress: POOL_ADDRESS,
+        fee: 3000,
+        lowerTick: -887220,
+        upperTick: 887220,
+      };
+      const v3Event2: LiquidityChange = {
+        tokenAddress,
+        lpAddress: LP_ADDRESS,
+        owner: NORMAL_USER_1,
+        changeType: LiquidityChangeType.Deposit,
+        liquidityChange: ARBITRARY_LIQUIDITY,
+        depositedBalanceChange: ONE,
+        blockNumber: 60,
+        timestamp: 1010,
+        __typename: "LiquidityV3Change",
+        transactionHash: txHash2,
+        tokenId: "42",
+        poolAddress: POOL_ADDRESS,
+        fee: 3000,
+        lowerTick: -100000,
+        upperTick: 100000,
+      };
+
+      await processor.organizeLiquidityPositions(v3Event1);
+      await processor.organizeLiquidityPositions(v3Event2);
+      processor.processLiquidityPositions(v3Event1);
+      expect(() => processor.processLiquidityPositions(v3Event2)).toThrow(
+        "Tick range mismatch",
+      );
+    });
+  });
+
   describe("Mixed-case owner address in liquidity positions", () => {
     it("should handle LP Transfer event with no prior processTransfer call", async () => {
       const tokenAddress = CYTOKENS[0].address;

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -54,7 +54,12 @@ function newAccountBalance(snapshotCount: number): AccountBalance {
 }
 
 /** Build a V3 LP position ID from token, owner, pool, and tokenId */
-function lpV3PositionId(token: string, owner: string, pool: string, tokenId: string): string {
+function lpV3PositionId(
+  token: string,
+  owner: string,
+  pool: string,
+  tokenId: string,
+): string {
   return `${token}-${owner}-${pool}-${tokenId}`;
 }
 
@@ -75,7 +80,10 @@ export class Processor {
   /** Snapshot block → position ID → V3 LP position for in-range checks */
   private lp3TrackList: Record<number, Map<string, LpV3Position>> = {};
   /** Owner → token → txHash → liquidity event, for deposit/withdraw matching */
-  private liquidityEvents: Map<string, Map<string, Map<string, LiquidityChange>>> = new Map();
+  private liquidityEvents: Map<
+    string,
+    Map<string, Map<string, LiquidityChange>>
+  > = new Map();
 
   /**
    * @param snapshots - Sorted array of 30 block numbers to sample balances at
@@ -141,7 +149,7 @@ export class Processor {
         })) as Address;
 
         const isApproved = FACTORIES.some((addr) =>
-          isSameAddress(addr, factory)
+          isSameAddress(addr, factory),
         );
         this.approvedSourceCache.set(source, isApproved);
         return isApproved;
@@ -166,7 +174,9 @@ export class Processor {
         }
 
         // If we've exhausted all retries, abort rather than silently under-crediting
-        throw new Error(`Failed to check factory for ${source} after ${retries} attempts: ${e.message}`);
+        throw new Error(
+          `Failed to check factory for ${source} after ${retries} attempts: ${e.message}`,
+        );
       }
     }
 
@@ -205,7 +215,7 @@ export class Processor {
     const value = BigInt(transfer.value);
 
     const accountBalances = this.accountBalancesPerToken.get(
-      transfer.tokenAddress
+      transfer.tokenAddress,
     );
 
     if (!accountBalances) {
@@ -214,10 +224,16 @@ export class Processor {
 
     // Initialize balances if needed
     if (!accountBalances.has(transfer.to)) {
-      accountBalances.set(transfer.to, newAccountBalance(this.snapshots.length));
+      accountBalances.set(
+        transfer.to,
+        newAccountBalance(this.snapshots.length),
+      );
     }
     if (!accountBalances.has(transfer.from)) {
-      accountBalances.set(transfer.from, newAccountBalance(this.snapshots.length));
+      accountBalances.set(
+        transfer.from,
+        newAccountBalance(this.snapshots.length),
+      );
     }
 
     // LP deposits and withdrawals are neutral to the bought cap —
@@ -254,16 +270,17 @@ export class Processor {
     const txhash = transfer.transactionHash;
     const owner = transfer.from;
 
-    const ownerEvents = this.liquidityEvents.get(owner)
+    const ownerEvents = this.liquidityEvents.get(owner);
     if (!ownerEvents) return;
 
-    const ownerTokenEvents = ownerEvents.get(token)
+    const ownerTokenEvents = ownerEvents.get(token);
     if (!ownerTokenEvents) return;
 
-    const ownerTokenTxEvent = ownerTokenEvents.get(txhash)
+    const ownerTokenTxEvent = ownerTokenEvents.get(txhash);
     if (!ownerTokenTxEvent) return;
 
-    if (ownerTokenTxEvent.changeType === LiquidityChangeType.Deposit) return ownerTokenTxEvent;
+    if (ownerTokenTxEvent.changeType === LiquidityChangeType.Deposit)
+      return ownerTokenTxEvent;
     return;
   }
 
@@ -286,7 +303,8 @@ export class Processor {
     const ownerTokenTxEvent = ownerTokenEvents.get(txhash);
     if (!ownerTokenTxEvent) return;
 
-    if (ownerTokenTxEvent.changeType === LiquidityChangeType.Withdraw) return ownerTokenTxEvent;
+    if (ownerTokenTxEvent.changeType === LiquidityChangeType.Withdraw)
+      return ownerTokenTxEvent;
     return;
   }
 
@@ -301,9 +319,7 @@ export class Processor {
       allAddresses.add(report.reporter);
     }
     for (const token of CYTOKENS) {
-      const accountBalances = this.accountBalancesPerToken.get(
-        token.address
-      );
+      const accountBalances = this.accountBalancesPerToken.get(token.address);
       if (!accountBalances) continue;
       for (const [address] of accountBalances) {
         allAddresses.add(address);
@@ -329,14 +345,16 @@ export class Processor {
 
       for (const address of allAddresses) {
         // Calculate balances for each token
-        const accountBalances = this.accountBalancesPerToken.get(
-          token.address
-        );
+        const accountBalances = this.accountBalancesPerToken.get(token.address);
         if (!accountBalances) continue;
 
         const balance = accountBalances.get(address);
-        const snapshots = balance?.netBalanceAtSnapshots ?? new Array<bigint>(this.snapshots.length).fill(0n);
-        const average = snapshots.reduce((acc, val) => acc + val, 0n) / BigInt(snapshots.length);
+        const snapshots =
+          balance?.netBalanceAtSnapshots ??
+          new Array<bigint>(this.snapshots.length).fill(0n);
+        const average =
+          snapshots.reduce((acc, val) => acc + val, 0n) /
+          BigInt(snapshots.length);
 
         userBalances.set(address, {
           snapshots,
@@ -382,7 +400,9 @@ export class Processor {
         const balance = userBalances.get(address);
         if (!balance) continue;
 
-        balance.final = balance.average - balance.penalty + balance.bounty;
+        balance.final = clamp0(
+          balance.average - balance.penalty + balance.bounty,
+        );
         balance.final18 = scaleTo18(balance.final, token.decimals);
       }
     }
@@ -396,7 +416,7 @@ export class Processor {
    * @returns Token address → total final18 balance
    */
   calculateTotalEligibleBalances(
-    balances: EligibleBalances
+    balances: EligibleBalances,
   ): Map<string, bigint> {
     // Calculate total of all final balances per token (after penalties)
     const totalBalances = new Map<string, bigint>();
@@ -405,7 +425,7 @@ export class Processor {
       if (!tokenBalances) continue;
       const totalBalance = Array.from(tokenBalances.values()).reduce(
         (acc, balance) => acc + balance.final18,
-        0n
+        0n,
       );
       totalBalances.set(token.address, totalBalance);
     }
@@ -417,9 +437,13 @@ export class Processor {
    * @param balances - Eligible balances from getEligibleBalances()
    * @returns CyToken definitions that have at least one account with balance
    */
-  getTokensWithBalance(balances: EligibleBalances, totalBalances?: Map<string, bigint>): CyToken[] {
+  getTokensWithBalance(
+    balances: EligibleBalances,
+    totalBalances?: Map<string, bigint>,
+  ): CyToken[] {
     const tokensWithBalance: CyToken[] = [];
-    const totals = totalBalances ?? this.calculateTotalEligibleBalances(balances);
+    const totals =
+      totalBalances ?? this.calculateTotalEligibleBalances(balances);
     for (const token of CYTOKENS) {
       if (totals.get(token.address)! > 0n) {
         tokensWithBalance.push(token);
@@ -446,40 +470,35 @@ export class Processor {
     rewardPool: bigint,
     totalBalances?: Map<string, bigint>,
   ): Map<string, bigint> {
-    const totals = totalBalances ?? this.calculateTotalEligibleBalances(balances);
+    const totals =
+      totalBalances ?? this.calculateTotalEligibleBalances(balances);
 
     // we only want to calculate rewards for tokens that have a balance
     const tokensWithBalance = this.getTokensWithBalance(balances, totals);
 
     const sumOfAllBalances = Array.from(totals.values()).reduce(
       (acc, balance) => acc + balance,
-      0n
+      0n,
     );
 
     // Calculate the inverse fractions for each token
     const tokenInverseFractions = new Map<string, bigint>();
     for (const token of tokensWithBalance) {
       const tokenInverseFraction =
-        (sumOfAllBalances * ONE_18) /
-        totals.get(token.address)!;
-      tokenInverseFractions.set(
-        token.address,
-        tokenInverseFraction
-      );
+        (sumOfAllBalances * ONE_18) / totals.get(token.address)!;
+      tokenInverseFractions.set(token.address, tokenInverseFraction);
     }
 
     // Sum of all inverse fractions
     const sumOfInverseFractions = Array.from(
-      tokenInverseFractions.values()
+      tokenInverseFractions.values(),
     ).reduce((acc, inverseFraction) => acc + inverseFraction, 0n);
 
     // Calculate each token's share of the reward pool.
     // BigInt truncation means token shares sum to <= rewardPool.
     const totalRewardsPerToken = new Map<string, bigint>();
     for (const token of tokensWithBalance) {
-      const tokenInverseFraction = tokenInverseFractions.get(
-        token.address
-      )!;
+      const tokenInverseFraction = tokenInverseFractions.get(token.address)!;
       const tokenReward =
         (tokenInverseFraction * rewardPool) / sumOfInverseFractions;
       totalRewardsPerToken.set(token.address, tokenReward);
@@ -495,7 +514,10 @@ export class Processor {
    * @param balances - Pre-computed eligible balances (avoids redundant getEligibleBalances call)
    * @returns Token address → user address → reward amount in wei
    */
-  async calculateRewards(rewardPool: bigint, balances: EligibleBalances): Promise<RewardsPerToken> {
+  async calculateRewards(
+    rewardPool: bigint,
+    balances: EligibleBalances,
+  ): Promise<RewardsPerToken> {
     const totalBalances = this.calculateTotalEligibleBalances(balances);
 
     const totalRewardsPerToken = this.calculateRewardsPoolsPerToken(
@@ -504,7 +526,10 @@ export class Processor {
       totalBalances,
     );
 
-    const tokensWithBalance = this.getTokensWithBalance(balances, totalBalances);
+    const tokensWithBalance = this.getTokensWithBalance(
+      balances,
+      totalBalances,
+    );
     // Calculate each address's share of the rewards
     const rewards = new Map<string, Map<string, bigint>>();
     for (const token of tokensWithBalance) {
@@ -517,8 +542,7 @@ export class Processor {
         // will be slightly less than the pool. This is the correct direction
         // (under-distribute, never over-distribute).
         const reward =
-          (balance.final18 *
-            totalRewardsPerToken.get(token.address)!) /
+          (balance.final18 * totalRewardsPerToken.get(token.address)!) /
           totalBalances.get(token.address)!;
         tokenRewards.set(address, reward);
       }
@@ -535,26 +559,46 @@ export class Processor {
    */
   organizeLiquidityPositions(liquidityChangeEvent: LiquidityChange) {
     // skip if the token is not in the eligible list
-    if (!CYTOKENS.some((v) => v.address === liquidityChangeEvent.tokenAddress)) {
+    if (
+      !CYTOKENS.some((v) => v.address === liquidityChangeEvent.tokenAddress)
+    ) {
       return;
     }
 
     const ownerEvents = this.liquidityEvents.get(liquidityChangeEvent.owner);
     if (!ownerEvents) {
-      this.liquidityEvents.set(liquidityChangeEvent.owner, new Map([[liquidityChangeEvent.tokenAddress, new Map([[liquidityChangeEvent.transactionHash, liquidityChangeEvent]])]]));
+      this.liquidityEvents.set(
+        liquidityChangeEvent.owner,
+        new Map([
+          [
+            liquidityChangeEvent.tokenAddress,
+            new Map([
+              [liquidityChangeEvent.transactionHash, liquidityChangeEvent],
+            ]),
+          ],
+        ]),
+      );
       return;
     }
 
     const ownerTokenEvents = ownerEvents.get(liquidityChangeEvent.tokenAddress);
     if (!ownerTokenEvents) {
-      ownerEvents.set(liquidityChangeEvent.tokenAddress, new Map([[liquidityChangeEvent.transactionHash, liquidityChangeEvent]]));
+      ownerEvents.set(
+        liquidityChangeEvent.tokenAddress,
+        new Map([[liquidityChangeEvent.transactionHash, liquidityChangeEvent]]),
+      );
       return;
     }
 
     if (ownerTokenEvents.has(liquidityChangeEvent.transactionHash)) {
-      throw new Error(`Duplicate liquidity event for owner=${liquidityChangeEvent.owner} token=${liquidityChangeEvent.tokenAddress} txHash=${liquidityChangeEvent.transactionHash}`);
+      throw new Error(
+        `Duplicate liquidity event for owner=${liquidityChangeEvent.owner} token=${liquidityChangeEvent.tokenAddress} txHash=${liquidityChangeEvent.transactionHash}`,
+      );
     }
-    ownerTokenEvents.set(liquidityChangeEvent.transactionHash, liquidityChangeEvent);
+    ownerTokenEvents.set(
+      liquidityChangeEvent.transactionHash,
+      liquidityChangeEvent,
+    );
   }
 
   /**
@@ -567,16 +611,20 @@ export class Processor {
    */
   processLiquidityPositions(liquidityChangeEvent: LiquidityChange) {
     // skip if the token is not in the eligible list
-    if (!CYTOKENS.some((v) => v.address === liquidityChangeEvent.tokenAddress)) {
+    if (
+      !CYTOKENS.some((v) => v.address === liquidityChangeEvent.tokenAddress)
+    ) {
       return;
     }
 
     // the value is positive if its deposit and negative if its
     // withdraw or transfer out, so we do not need to apply +/-
-    const depositedBalanceChange = BigInt(liquidityChangeEvent.depositedBalanceChange);
+    const depositedBalanceChange = BigInt(
+      liquidityChangeEvent.depositedBalanceChange,
+    );
 
     const accountBalances = this.accountBalancesPerToken.get(
-      liquidityChangeEvent.tokenAddress
+      liquidityChangeEvent.tokenAddress,
     );
 
     if (!accountBalances) {
@@ -585,7 +633,10 @@ export class Processor {
 
     // Initialize balances if needed
     if (!accountBalances.has(liquidityChangeEvent.owner)) {
-      accountBalances.set(liquidityChangeEvent.owner, newAccountBalance(this.snapshots.length));
+      accountBalances.set(
+        liquidityChangeEvent.owner,
+        newAccountBalance(this.snapshots.length),
+      );
     }
 
     const ownerBalance = accountBalances.get(liquidityChangeEvent.owner)!;
@@ -610,7 +661,7 @@ export class Processor {
             lowerTick: liquidityChangeEvent.lowerTick,
             upperTick: liquidityChangeEvent.upperTick,
           };
-          prev.value += depositedBalanceChange
+          prev.value += depositedBalanceChange;
           this.lp3TrackList[this.snapshots[i]].set(id, prev);
         }
       }
@@ -631,11 +682,7 @@ export class Processor {
       const lpTrackList = this.lp3TrackList[this.snapshots[i]];
 
       // get pools ticks for this snapshot block
-      const poolsTicks = await getPoolsTick(
-        this.client,
-        this.pools,
-        block,
-      );
+      const poolsTicks = await getPoolsTick(this.client, this.pools, block);
 
       // Collect deductions per token+owner from out-of-range positions
       const deductions = new Map<string, Map<string, bigint>>();
@@ -653,7 +700,10 @@ export class Processor {
 
         if (!deductions.has(token)) deductions.set(token, new Map());
         const ownerDeductions = deductions.get(token)!;
-        ownerDeductions.set(owner, (ownerDeductions.get(owner) ?? 0n) + lp.value);
+        ownerDeductions.set(
+          owner,
+          (ownerDeductions.get(owner) ?? 0n) + lp.value,
+        );
       }
 
       // Apply deductions to snapshot balances

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -661,6 +661,14 @@ export class Processor {
             lowerTick: liquidityChangeEvent.lowerTick,
             upperTick: liquidityChangeEvent.upperTick,
           };
+          if (
+            prev.lowerTick !== liquidityChangeEvent.lowerTick ||
+            prev.upperTick !== liquidityChangeEvent.upperTick
+          ) {
+            throw new Error(
+              `Tick range mismatch for V3 position ${id}: expected [${prev.lowerTick}, ${prev.upperTick}], got [${liquidityChangeEvent.lowerTick}, ${liquidityChangeEvent.upperTick}]`,
+            );
+          }
           prev.value += depositedBalanceChange;
           this.lp3TrackList[this.snapshots[i]].set(id, prev);
         }

--- a/src/scraper.test.ts
+++ b/src/scraper.test.ts
@@ -19,7 +19,8 @@ const VALID_SUBGRAPH_TRANSFER: SubgraphTransfer = {
   value: "500000000000000000000",
   blockNumber: "12345678",
   blockTimestamp: "1700000000",
-  transactionHash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  transactionHash:
+    "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 };
 
 /** Minimal valid V2 subgraph liquidity change */
@@ -34,7 +35,8 @@ const VALID_V2_LIQUIDITY: SubgraphLiquidityChangeV2 = {
   depositedBalanceChange: "500000",
   blockNumber: "12345678",
   blockTimestamp: "1700000000",
-  transactionHash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  transactionHash:
+    "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 };
 
 /** Minimal valid V3 subgraph liquidity change */
@@ -49,7 +51,8 @@ const VALID_V3_LIQUIDITY: SubgraphLiquidityChangeV3 = {
   depositedBalanceChange: "500000",
   blockNumber: "12345678",
   blockTimestamp: "1700000000",
-  transactionHash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  transactionHash:
+    "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
   tokenId: "42",
   poolAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
   fee: "3000",
@@ -74,7 +77,9 @@ describe("mapSubgraphTransfer", () => {
     const result = mapSubgraphTransfer(VALID_SUBGRAPH_TRANSFER);
     expect(result.tokenAddress).toBe(VALID_SUBGRAPH_TRANSFER.tokenAddress);
     expect(result.value).toBe(VALID_SUBGRAPH_TRANSFER.value);
-    expect(result.transactionHash).toBe(VALID_SUBGRAPH_TRANSFER.transactionHash);
+    expect(result.transactionHash).toBe(
+      VALID_SUBGRAPH_TRANSFER.transactionHash,
+    );
   });
 
   it("should not include the subgraph id field in the output", () => {
@@ -104,7 +109,10 @@ describe("mapSubgraphTransfer", () => {
   });
 
   it("should throw on invalid from address", () => {
-    const transfer = { ...VALID_SUBGRAPH_TRANSFER, from: { id: "not-an-address" } };
+    const transfer = {
+      ...VALID_SUBGRAPH_TRANSFER,
+      from: { id: "not-an-address" },
+    };
     expect(() => mapSubgraphTransfer(transfer)).toThrow("from");
   });
 
@@ -127,6 +135,19 @@ describe("mapSubgraphTransfer", () => {
     const transfer = { ...VALID_SUBGRAPH_TRANSFER, value: "0" };
     expect(() => mapSubgraphTransfer(transfer)).not.toThrow();
   });
+
+  it("should throw on invalid transactionHash format", () => {
+    const transfer = {
+      ...VALID_SUBGRAPH_TRANSFER,
+      transactionHash: "not-a-hash",
+    };
+    expect(() => mapSubgraphTransfer(transfer)).toThrow("transactionHash");
+  });
+
+  it("should throw on transactionHash with wrong length", () => {
+    const transfer = { ...VALID_SUBGRAPH_TRANSFER, transactionHash: "0xabc" };
+    expect(() => mapSubgraphTransfer(transfer)).toThrow("transactionHash");
+  });
 });
 
 describe("mapSubgraphLiquidityChange", () => {
@@ -144,7 +165,9 @@ describe("mapSubgraphLiquidityChange", () => {
     expect(result.__typename).toBe("LiquidityV3Change");
     if (result.__typename === "LiquidityV3Change") {
       expect(result.tokenId).toBe("42");
-      expect(result.poolAddress).toBe("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+      expect(result.poolAddress).toBe(
+        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      );
       expect(result.fee).toBe(3000);
       expect(result.lowerTick).toBe(-887272);
       expect(result.upperTick).toBe(887272);
@@ -255,7 +278,9 @@ describe("mapSubgraphLiquidityChange", () => {
 
   it("should throw on unknown liquidityChangeType", () => {
     const liq = { ...VALID_V2_LIQUIDITY, liquidityChangeType: "SWAP" as any };
-    expect(() => mapSubgraphLiquidityChange(liq)).toThrow("liquidityChangeType");
+    expect(() => mapSubgraphLiquidityChange(liq)).toThrow(
+      "liquidityChangeType",
+    );
   });
 
   it("should throw on non-numeric V3 fee", () => {
@@ -285,7 +310,9 @@ describe("mapSubgraphLiquidityChange", () => {
 
   it("should throw on non-numeric depositedBalanceChange", () => {
     const liq = { ...VALID_V2_LIQUIDITY, depositedBalanceChange: "xyz" };
-    expect(() => mapSubgraphLiquidityChange(liq)).toThrow("depositedBalanceChange");
+    expect(() => mapSubgraphLiquidityChange(liq)).toThrow(
+      "depositedBalanceChange",
+    );
   });
 
   it("should accept negative liquidityChange", () => {
@@ -309,6 +336,20 @@ describe("mapSubgraphLiquidityChange", () => {
       __typename: "LiquidityV99Change" as any,
     };
     expect(() => mapSubgraphLiquidityChange(unknown)).toThrow("__typename");
+  });
+
+  it("should throw on invalid transactionHash format (V2)", () => {
+    const invalid = { ...VALID_V2_LIQUIDITY, transactionHash: "not-a-hash" };
+    expect(() => mapSubgraphLiquidityChange(invalid)).toThrow(
+      "transactionHash",
+    );
+  });
+
+  it("should throw on invalid transactionHash format (V3)", () => {
+    const invalid = { ...VALID_V3_LIQUIDITY, transactionHash: "0xabc" };
+    expect(() => mapSubgraphLiquidityChange(invalid)).toThrow(
+      "transactionHash",
+    );
   });
 });
 
@@ -348,4 +389,3 @@ describe("UNTIL_SNAPSHOT", () => {
     expect(UNTIL_SNAPSHOT).toBe(epoch.endBlock);
   });
 });
-

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -125,6 +125,14 @@ function validateIntegerString(value: string, field: string): void {
     throw new Error(`Invalid ${field}: "${value}" is not an integer string`);
 }
 
+/** Validate that a string is a valid Ethereum transaction hash (0x + 64 hex chars) */
+function validateTxHash(value: string, field: string): void {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(value))
+    throw new Error(
+      `Invalid ${field}: "${value}" is not a valid transaction hash`,
+    );
+}
+
 /**
  * Maps a raw subgraph transfer event to the internal Transfer type.
  * Flattens nested from/to objects and parses numeric strings.
@@ -135,6 +143,7 @@ export function mapSubgraphTransfer(t: SubgraphTransfer): Transfer {
   validateAddress(t.from.id, "from");
   validateAddress(t.to.id, "to");
   validateNumericString(t.value, "value");
+  validateTxHash(t.transactionHash, "transactionHash");
   return {
     tokenAddress: t.tokenAddress,
     from: t.from.id,
@@ -162,6 +171,7 @@ export function mapSubgraphLiquidityChange(
   }
   validateIntegerString(t.liquidityChange, "liquidityChange");
   validateIntegerString(t.depositedBalanceChange, "depositedBalanceChange");
+  validateTxHash(t.transactionHash, "transactionHash");
   const base = {
     tokenAddress: t.tokenAddress,
     lpAddress: t.lpAddress,


### PR DESCRIPTION
## Summary

Triage of 17 audit issues from the 2026-04-13 audit (Pass 0 + Pass 1).

**Fixed (12):** #197 #198 #199 #200 #203 #206 #207 #208 #210 #211 #212 #213
**Dismissed (5):** #201 #202 #204 #205 #209

### Fixes

- Update CLAUDE.md env vars section — SEED/START/END are in EPOCHS now (#197)
- Update readme.md epoch transition process — match current setup (#198)
- Add missing files to CLAUDE.md Architecture section (#199)
- `verifyRewardPoolTolerance` rejects any over-distribution (#200)
- `generateSnapshotBlocks` asserts start <= end (#203)
- `parsePools` lowercases addresses (#206)
- `getEligibleBalances` clamps final to zero (#207)
- V3 LP position tick range consistency assertion (#208)
- Distribution test skips (not passes) on no data (#210)
- Scraper validates transactionHash (#211)
- Distribution test paginates across explorer pages (#212)
- `localDataIntegrity` asserts at least one event (#213)

### Dismissed

- #201: Greedy allocation is knapsack (NP-hard)
- #202, #204, #205: Dec 2025 reconciliation path already paid out
- #209: Goldsky pagination works fine; assertNoPaginationCeiling guards truncation

## Test plan
- [ ] CI passes (git-clean determinism check)
- [ ] All existing tests pass
- [ ] New tests for each fix pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)